### PR TITLE
mean_centering_per_study to apply *scale* in the lapply function

### DIFF
--- a/R/internal_mint.block_helpers.R
+++ b/R/internal_mint.block_helpers.R
@@ -258,7 +258,7 @@ mean_centering_per_study=function(data, study, scale)
     data.list.study = study_split(data, study)
 
     # center and scale data per group, and concatene the data
-    res = lapply(data.list.study, scale.function, scale = scale)
+    res = lapply(data.list.study, function(x) scale.function(x,scale = scale))
     
     meanX = lapply(res, function(x){x[[2]]})
     sqrt.sdX = lapply(res, function(x){x[[3]]})


### PR DESCRIPTION
_scale_ argument to be passed to _scale.function_ when using _lapply_ in _mean_centering_per_study_