### PR TITLE
Add conversion from list to matrix for weights when single component

### DIFF
--- a/R/perf.diablo.R
+++ b/R/perf.diablo.R
@@ -181,7 +181,7 @@ perf.sgccda <-
       
       ### Retrieve weights
       weights = sapply(1:M, function(x){model[[x]]$weights})
-      if (is.list(weights)) {
+      if (!is.matrix(weights)) {
         # In a single component model, the sapply function can create a list
         # instead of the the expected matrix
         weights <- t(as.matrix(weights))

--- a/R/perf.diablo.R
+++ b/R/perf.diablo.R
@@ -181,6 +181,14 @@ perf.sgccda <-
       
       ### Retrieve weights
       weights = sapply(1:M, function(x){model[[x]]$weights})
+      if (is.list(weights)) {
+        # In a single component model, the sapply function can create a list
+        # instead of the the expected matrix
+        weights <- t(as.matrix(weights))
+        rownames(weights) <- c("comp1")
+      }
+
+      ### Add fold counts to column names
       colnames(weights) = names(crit) = paste0("fold",1:M)
       
       ### Retrieve selected variables per component

--- a/tests/testthat/test-perf.diablo.R
+++ b/tests/testthat/test-perf.diablo.R
@@ -44,3 +44,28 @@ test_that("perf.diablo works with and without parallel processing and with auroc
     aucs <- round(unname(perf.res42$auc$comp1[,1]), 2)
     expect_equal(aucs,c(0.97, 0.66, 0.6, 0.59, 0.79))
 })
+
+test_that("perf.diablo is able to process a model with one component only", {
+    data(nutrimouse)
+    nrep <- 3
+    folds <- 2
+    Y = nutrimouse$diet
+    data = list(gene = nutrimouse$gene, lipid = nutrimouse$lipid)
+    design = matrix(c(0,1,1,1,0,1,1,1,0), ncol = 3, nrow = 3, byrow = TRUE)
+    
+    nutrimouse.sgccda <- block.splsda(X=data,
+                                      Y = Y,
+                                      design = design,
+                                      keepX = list(gene=c(10), lipid=c(15)),
+                                      ncomp = 1,
+                                      scheme = "horst")
+    
+    RNGversion(.mixo_rng()) ## in case RNG changes!
+    set.seed(100)
+    
+    # Running perf.sgccda would previously throw an exception when weights were not in a matrix format
+    perf.res = perf.sgccda(nutrimouse.sgccda, folds = folds, nrepeat = nrep, auc = FALSE, progressBar = TRUE)
+    
+    error.rates.comp.count <- nrow(perf.res$error.rate[[1]])
+    expect_equal(error.rates.comp.count, 1)
+})


### PR DESCRIPTION
A single component model has weights stored as a data frame with a single column.  sapply simplifies these down to a list of numeric vectors instead of the expected matrix of models x components.  This if block checks for the list output and converts it to the expected matrix in the correct orientation and correct row name.