### PR TITLE
Remove `mode = regression` when calling splsda

### DIFF
--- a/R/tune.splsda.R
+++ b/R/tune.splsda.R
@@ -598,7 +598,7 @@ tune.splsda <-
             
             for (i in 1:length(test.keepX))
             {
-                spls.train = mixOmics::splsda(X, Y, ncomp = ncomp, keepX = c(already.tested.X, test.keepX[i]), logratio = logratio, near.zero.var = FALSE, mode = "regression")
+                spls.train = mixOmics::splsda(X, Y, ncomp = ncomp, keepX = c(already.tested.X, test.keepX[i]), logratio = logratio, near.zero.var = FALSE)
                 
                 # Note: this is performed on the full data set
                 # (could be done with resampling (bootstrap) (option 1) and/or prediction (option 2))


### PR DESCRIPTION
This was not removed from splsda, resulting in "unused argument" bug. See [commit](https://github.com/mixOmicsTeam/mixOmics/commit/169bb4ebac034c0a2b3998a45f285fe42a0f2b2d).