### PR TITLE
Fixed ambiguous error in tune.spca()

### DIFF
--- a/R/tune.spca.R
+++ b/R/tune.spca.R
@@ -76,6 +76,22 @@ tune.spca <- function(X,
                     ## split data to train/test
                     X.train = X[-test.fold.inds,,drop=FALSE]
                     X.test = X[test.fold.inds,,drop=FALSE]
+                    
+                    # find indices of rows in X.train that contain NAs
+                    rows.NAs.train <- rowSums(is.na(X.train))
+                    rows.NAs.train <- which(rownames(X.train) %in% names(rows.NAs.train[rows.NAs.train!= 0]))
+                    
+                    # find indices of rows in X.test that contain NAs
+                    rows.NAs.test <- rowSums(is.na(X.test))
+                    rows.NAs.test <- which(rownames(X.test) %in% names(rows.NAs.test[rows.NAs.test!= 0]))
+                    
+                    # if there are rows with NAs, remove them from the appropriate sets
+                    if (length(rows.NAs.train)>0) {X.train <- X.train[-rows.NAs.train,]}
+                    if (length(rows.NAs.test)>0) {
+                        X.test <- X.test[-rows.NAs.test,]
+                        t.comp.actual <- t.comp.actual[-rows.NAs.test]
+                    }
+                    
                     # ---- run sPCA 
                     ## train
                     spca.train = spca(X.train, ncomp = ncomp, keepX = c(keepX.opt, keepX.value), center = center, scale = FALSE)
@@ -89,7 +105,7 @@ tune.spca <- function(X,
                         } else{
                             # calculate deflation beyond comp 1
                             # recalculate the loading vector (here c.sub) on the test set (perhaps we could do this instead on the training set by extracting from spca.train$loadings$X[,k]?)
-                            c.sub = crossprod(X.test, t.comp.pred) / drop(crossprod(t.comp.pred)) 
+                            c.sub = crossprod(X.test, t.comp.pred) / drop(crossprod(t.comp.pred))
                             X.test = X.test - t.comp.pred %*% t(c.sub) 
                             # update predicted comp based on deflated matrix
                             t.comp.pred = X.test %*% spca.train$loadings$X[,k]


### PR DESCRIPTION
SOURCE:
https://github.com/mixOmicsTeam/mixOmics/issues/161

PROBLEM TO BE RESOLVED:
User has dataframe (72 x 48) with some NAs. When they attempt to use `tune.pca()`, works fine. When they attempt the below call:

`grid.keepX<-c(seq(5,30,5))`
`tune.spca.result<-tune.spca(X, ncomp=3, folds=4, test.keepX=grid.keepX, nrepeat=10)`

The follow error is raised:
` Error: Unexpected error while trying to choose the optimum number of components. Please check the inputs and if problem persists submit an issue ...`

Worked when `nrepeat = 2` or less, but more than that and it breaks.

SOLUTION:
Adjusted lines 78-93 involved removing the rows of any `X.train`, `X.test` and `t.comp.pred` rows which had an `NA` within them. This is done within the `repeat_cv_j` function such that no data at the global level is lost. Allows cross product to be calculated within inducing any `NA`'s

@aljabadi 