### PR TITLE
Fix for issue #167

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -47,8 +47,8 @@ jobs:
             bioc="latest"
             r="$r_release"
           else
-            bioc="devel"
-            r="$r_devel"
+            bioc="latest"
+            r="$r_release"
           fi
           echo ::set-output name=r::$r
           echo ::set-output name=bioc::$bioc

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mixOmics
 Type: Package
 Title: Omics Data Integration Project
-Version: 6.19.1
+Version: 6.19.2
 Depends: R (>= 3.5.0), 
          MASS, 
          lattice, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mixOmics
 Type: Package
 Title: Omics Data Integration Project
-Version: 6.19.2
+Version: 6.19.3
 Depends: R (>= 3.5.0), 
          MASS, 
          lattice, 

--- a/R/S3methods-plot.tune.R
+++ b/R/S3methods-plot.tune.R
@@ -612,7 +612,7 @@ plot.tune.spls1 <-
             scale_color_manual(values = col)
         
         # error bar
-        if(!is.null(error.rate.sd))
+        if(!is.null(error.rate.sd) && sd)
         {
             dferror = melt(error.rate.sd)
             df$lwr = df$y - dferror$value

--- a/R/S3methods-plot.tune.R
+++ b/R/S3methods-plot.tune.R
@@ -537,18 +537,14 @@ plot.tune.spls1 <-
         
         
         error <- x$error.rate
-        if(sd == TRUE)
-        {
-            if (!is.null(x$error.rate.sd)) 
-            {
-                error.rate.sd = x$error.rate.sd
-                ylim = range(c(error + error.rate.sd), c(error - error.rate.sd))
-            } else {
-                message("sd bars cannot be calculated when nrepeat = 1.\n")
-            }
-        } else {
-            error.rate.sd = NULL
+        error.rate.sd = x$error.rate.sd # for LOGOCV and nrepeat=1, will be NULL
+        
+        #
+        if (is.null(x$error.rate.sd)) {
+            message("Note: sd bars cannot be calculated when nrepeat = 1.\n")
             ylim = range(error)
+        } else {
+            ylim = range(c(error + error.rate.sd), c(error - error.rate.sd))
         }
         
         optimal <- optimal && (any(grepl('mint', class(x))) || x$call$nrepeat > 2)

--- a/R/S3methods-plot.tune.R
+++ b/R/S3methods-plot.tune.R
@@ -204,15 +204,14 @@ plot.tune.spls <-
 #' @importFrom reshape2 melt
 #' @export
 plot.tune.splsda <-
-    function(x, optimal = TRUE, sd = TRUE, col, ...)
+    function(x, optimal = TRUE, sd = NULL, col, ...)
     {
         # to satisfy R CMD check that doesn't recognise x, y and group (in aes)
         y = Comp = lwr = upr = NULL
         
         if (!is.logical(optimal))
             stop("'optimal' must be logical.", call. = FALSE)
-        
-        
+        sd = .change_if_null(sd, !is.null(x$error.rate.sd))
         error <- x$error.rate
         if(sd & !is.null(x$error.rate.sd))
         {
@@ -317,12 +316,13 @@ plot.tune.splsda <-
 #' @method plot tune.block.splsda
 #' @export
 plot.tune.block.splsda =
-    function(x, sd = TRUE, col, ...)
+    function(x, sd = NULL, col, ...)
     {
         
         # R check
         error.sd=NULL
         
+        sd = .change_if_null(sd, !is.null(x$error.rate.sd))
         error <- x$error.rate
         if(sd & !is.null(x$error.rate.sd))
         {
@@ -526,7 +526,7 @@ plot.tune.spca <-
 #' @importFrom reshape2 melt
 #' @export
 plot.tune.spls1 <-
-    function(x, optimal = TRUE, sd = TRUE, col, ...)
+    function(x, optimal = TRUE, sd = NULL, col, ...)
     {
         # TODO add examples
         # to satisfy R CMD check that doesn't recognise x, y and group (in aes)
@@ -534,8 +534,7 @@ plot.tune.spls1 <-
         
         if (!is.logical(optimal))
             stop("'optimal' must be logical.", call. = FALSE)
-        
-        
+        sd = .change_if_null(sd, !is.null(x$error.rate.sd))
         error <- x$error.rate
         if(sd == TRUE)
         {

--- a/R/tune.splsda.R
+++ b/R/tune.splsda.R
@@ -274,7 +274,7 @@ tune.splsda <-
         }
         
         if (nrepeat < 3 & ncomp > 1)
-            message("Noe that the number of components cannot be reliably tuned with nrepeat < 3 or validaion = 'loo'.")
+            message("Note that the number of components cannot be reliably tuned with nrepeat < 3 or validaion = 'loo'.")
         #-- logratio
         logratio <- match.arg(logratio)
         
@@ -587,6 +587,7 @@ tune.splsda <-
             }
             result$measure = measure
             result$call = match.call()
+            result$nrepeat = nrepeat
             
             class(result) = "tune.splsda"
             

--- a/R/tune.splsda.R
+++ b/R/tune.splsda.R
@@ -274,7 +274,7 @@ tune.splsda <-
         }
         
         if (nrepeat < 3 & ncomp > 1)
-            message("Noe that the number of components cannot be reliably tuned with nrepeat < 3 or validaion = 'loo'.")
+            message("Note that the number of components cannot be reliably tuned with nrepeat < 3 or validaion = 'loo'.")
         #-- logratio
         logratio <- match.arg(logratio)
         
@@ -587,6 +587,7 @@ tune.splsda <-
             }
             result$measure = measure
             result$call = match.call()
+            result$call$nrepeat = nrepeat
             
             class(result) = "tune.splsda"
             

--- a/man/plot.tune.Rd
+++ b/man/plot.tune.Rd
@@ -21,15 +21,15 @@
   ...
 )
 
-\method{plot}{tune.splsda}(x, optimal = TRUE, sd = TRUE, col, ...)
+\method{plot}{tune.splsda}(x, optimal = TRUE, sd = NULL, col, ...)
 
-\method{plot}{tune.block.splsda}(x, sd = TRUE, col, ...)
+\method{plot}{tune.block.splsda}(x, sd = NULL, col, ...)
 
 \method{plot}{tune.spca}(x, optimal = TRUE, sd = NULL, col = NULL, ...)
 
-\method{plot}{tune.spls1}(x, optimal = TRUE, sd = TRUE, col, ...)
+\method{plot}{tune.spls1}(x, optimal = TRUE, sd = NULL, col, ...)
 
-\method{plot}{tune.splsda}(x, optimal = TRUE, sd = TRUE, col, ...)
+\method{plot}{tune.splsda}(x, optimal = TRUE, sd = NULL, col, ...)
 }
 \arguments{
 \item{x}{an \code{tune.splsda} object.}


### PR DESCRIPTION
SOURCE:
https://github.com/mixOmicsTeam/mixOmics/issues/167

SOLUTION:
First commit:
Added a check at `line 540` in `plot.tune.spls1()` which uses the presence of the `x$error.rate.sd` component to determine whether error bars can be used. If a `tune.splsda` object was formed without explicit `nrepeat`, `call$nrepeat` would be `NA`, resulting in `optimal = NA` in `plot.tune.spls1()`. Therefore, added `line 590` in `tune.splsda()` which forces the `call` component to include the `nrepeat` parameter, whether or not it was explicitly defined. 

Second commit: 
At `line 615`, the `sd` parameter is added to the `if()` statement which controls drawing of the error bars (as `sd` functionality was lost during first commit)