### PR TITLE
fix: CI: use r-release

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -48,7 +48,7 @@ jobs:
             r="$r_release"
           else
             bioc="devel"
-            r="$r_devel"
+            r="$r_release"
           fi
           echo ::set-output name=r::$r
           echo ::set-output name=bioc::$bioc


### PR DESCRIPTION
r_devel builds are failing. This PR aims to investigate whether the build issues are specific to the unstable version of R.