### PR TITLE
use r and bioc release on master

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -47,8 +47,8 @@ jobs:
             bioc="latest"
             r="$r_release"
           else
-            bioc="devel"
-            r="$r_devel"
+            bioc="latest"
+            r="$r_release"
           fi
           echo ::set-output name=r::$r
           echo ::set-output name=bioc::$bioc


### PR DESCRIPTION
GH Actions builds are failing on master. The issues might be caused by unstable versions of R and/or dependencies. Since we do not have to make the devel build stable atm since no release schedule has yet been announced (https://bioconductor.org/developers/release-schedule/), this PR aims to investigate whether we can continue building on master using stable versions of R and bioc. If #173 's build is successful, we can close this change which is more invasive than that PR.