### PR TITLE
PR addressing Issue #161

### DIFF
--- a/R/tune.spca.R
+++ b/R/tune.spca.R
@@ -76,6 +76,24 @@ tune.spca <- function(X,
                     ## split data to train/test
                     X.train = X[-test.fold.inds,,drop=FALSE]
                     X.test = X[test.fold.inds,,drop=FALSE]
+                    
+                    
+                    
+                    # find indices of rows in X.train that contain NAs
+                    rows.NAs.train <- rowSums(is.na(X.train))
+                    rows.NAs.train <- which(rownames(X.train) %in% names(rows.NAs.train[rows.NAs.train!= 0]))
+                    
+                    # find indices of rows in X.test that contain NAs
+                    rows.NAs.test <- rowSums(is.na(X.test))
+                    rows.NAs.test <- which(rownames(X.test) %in% names(rows.NAs.test[rows.NAs.test!= 0]))
+                    
+                    # if there are rows with NAs, remove them from the appropriate sets
+                    if (length(rows.NAs.train)>0) {X.train <- X.train[-rows.NAs.train,]}
+                    if (length(rows.NAs.test)>0) {
+                        X.test <- X.test[-rows.NAs.test,]
+                        t.comp.actual <- t.comp.actual[-rows.NAs.test]
+                    }
+                    
                     # ---- run sPCA 
                     ## train
                     spca.train = spca(X.train, ncomp = ncomp, keepX = c(keepX.opt, keepX.value), center = center, scale = FALSE)


### PR DESCRIPTION
User has dataframe (72 x 48) with some `NA`s. When they attempt to use `tune.pca()`, works fine. When they attempt the below call:

`grid.keepX<-c(seq(5,30,5))`
`tune.spca.result<-tune.spca(X, ncomp=3, folds=4, test.keepX=grid.keepX, nrepeat=10)`

The follow error is raised:
`Error: Unexpected error while trying to choose the optimum number of components. Please check the inputs and if problem persists submit an issue ...`

Worked when `nrepeat = 2` or less, but more than that and it breaks.

``` r
suppressMessages(library(mixOmics))
data(nutrimouse)

grid.keepX<-c(seq(5,30,5)) # recreate grid from issue #161

## run tuning with no NAs
X <- nutrimouse$gene
tune.spca.result.full <- tune.spca(X, ncomp=3, folds=4, nrepeat=10,
                                   test.keepX = grid.keepX)

## introduce a single NA to ~15% of rows in the data frame
for (r in sample(nrow(X), floor(0.15*nrow(X)))) {
  X[r, sample(ncol(X), 1)] <- NA
}

## run tuning with NAs
tune.spca.result.NAs <- tune.spca(X, ncomp=3, folds=4, nrepeat=10,
                                  test.keepX = grid.keepX)
#> Error: Unexpected error while trying to choose the optimum number of components. Please check the inputs and if problem persists submit an issue to https://github.com/mixOmicsTeam/mixOmics/issues
```

<sup>Created on 2022-03-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> - Session info ---------------------------------------------------------------
#>  setting  value
#>  version  R version 4.1.2 Patched (2021-11-16 r81220)
#>  os       Windows 10 x64 (build 19042)
#>  system   x86_64, mingw32
#>  ui       RTerm
#>  language (EN)
#>  collate  English_Australia.1252
#>  ctype    English_Australia.1252
#>  tz       Australia/Sydney
#>  date     2022-03-08
#>  pandoc   2.14.2 @ C:/Users/Work/AppData/Local/Pandoc/ (via rmarkdown)
#> 
#> - Packages -------------------------------------------------------------------
#>  package      * version date (UTC) lib source
#>  backports      1.4.1   2021-12-13 [1] CRAN (R 4.1.2)
#>  BiocParallel   1.28.1  2021-11-18 [1] Bioconductor
#>  cli            3.2.0   2022-02-14 [1] CRAN (R 4.1.2)
#>  colorspace     2.0-3   2022-02-21 [1] CRAN (R 4.1.2)
#>  corpcor        1.6.10  2021-09-16 [1] CRAN (R 4.1.1)
#>  crayon         1.5.0   2022-02-14 [1] CRAN (R 4.1.2)
#>  digest         0.6.29  2021-12-01 [1] CRAN (R 4.1.2)
#>  dplyr          1.0.8   2022-02-08 [1] CRAN (R 4.1.2)
#>  ellipse        0.4.2   2020-05-27 [1] CRAN (R 4.1.2)
#>  ellipsis       0.3.2   2021-04-29 [1] CRAN (R 4.1.2)
#>  evaluate       0.15    2022-02-18 [1] CRAN (R 4.1.2)
#>  fansi          1.0.2   2022-01-14 [1] CRAN (R 4.1.2)
#>  fastmap        1.1.0   2021-01-25 [1] CRAN (R 4.1.2)
#>  fs             1.5.2   2021-12-08 [1] CRAN (R 4.1.2)
#>  generics       0.1.2   2022-01-31 [1] CRAN (R 4.1.2)
#>  ggplot2      * 3.3.5   2021-06-25 [1] CRAN (R 4.1.2)
#>  ggrepel        0.9.1   2021-01-15 [1] CRAN (R 4.1.2)
#>  glue           1.6.2   2022-02-24 [1] CRAN (R 4.1.2)
#>  gridExtra      2.3     2017-09-09 [1] CRAN (R 4.1.2)
#>  gtable         0.3.0   2019-03-25 [1] CRAN (R 4.1.2)
#>  highr          0.9     2021-04-16 [1] CRAN (R 4.1.2)
#>  htmltools      0.5.2   2021-08-25 [1] CRAN (R 4.1.2)
#>  igraph         1.2.11  2022-01-04 [1] CRAN (R 4.1.2)
#>  knitr          1.37    2021-12-16 [1] CRAN (R 4.1.2)
#>  lattice      * 0.20-45 2021-09-22 [2] CRAN (R 4.1.2)
#>  lifecycle      1.0.1   2021-09-24 [1] CRAN (R 4.1.2)
#>  magrittr       2.0.2   2022-01-26 [1] CRAN (R 4.1.2)
#>  MASS         * 7.3-54  2021-05-03 [2] CRAN (R 4.1.2)
#>  Matrix         1.3-4   2021-06-01 [2] CRAN (R 4.1.2)
#>  matrixStats    0.61.0  2021-09-17 [1] CRAN (R 4.1.2)
#>  mixOmics     * 6.18.1  2021-11-18 [1] Bioconductor (R 4.1.2)
#>  munsell        0.5.0   2018-06-12 [1] CRAN (R 4.1.2)
#>  pillar         1.7.0   2022-02-01 [1] CRAN (R 4.1.2)
#>  pkgconfig      2.0.3   2019-09-22 [1] CRAN (R 4.1.2)
#>  plyr           1.8.6   2020-03-03 [1] CRAN (R 4.1.2)
#>  purrr          0.3.4   2020-04-17 [1] CRAN (R 4.1.2)
#>  R.cache        0.15.0  2021-04-30 [1] CRAN (R 4.1.2)
#>  R.methodsS3    1.8.1   2020-08-26 [1] CRAN (R 4.1.1)
#>  R.oo           1.24.0  2020-08-26 [1] CRAN (R 4.1.1)
#>  R.utils        2.11.0  2021-09-26 [1] CRAN (R 4.1.2)
#>  R6             2.5.1   2021-08-19 [1] CRAN (R 4.1.2)
#>  rARPACK        0.11-0  2016-03-10 [1] CRAN (R 4.1.2)
#>  RColorBrewer   1.1-2   2014-12-07 [1] CRAN (R 4.1.1)
#>  Rcpp           1.0.8   2022-01-13 [1] CRAN (R 4.1.2)
#>  reprex         2.0.1   2021-08-05 [1] CRAN (R 4.1.2)
#>  reshape2       1.4.4   2020-04-09 [1] CRAN (R 4.1.2)
#>  rlang          1.0.1   2022-02-03 [1] CRAN (R 4.1.2)
#>  rmarkdown      2.12    2022-03-02 [1] CRAN (R 4.1.2)
#>  RSpectra       0.16-0  2019-12-01 [1] CRAN (R 4.1.2)
#>  rstudioapi     0.13    2020-11-12 [1] CRAN (R 4.1.2)
#>  scales         1.1.1   2020-05-11 [1] CRAN (R 4.1.2)
#>  sessioninfo    1.2.2   2021-12-06 [1] CRAN (R 4.1.2)
#>  stringi        1.7.6   2021-11-29 [1] CRAN (R 4.1.2)
#>  stringr        1.4.0   2019-02-10 [1] CRAN (R 4.1.2)
#>  styler         1.6.2   2021-09-23 [1] CRAN (R 4.1.2)
#>  tibble         3.1.6   2021-11-07 [1] CRAN (R 4.1.2)
#>  tidyr          1.2.0   2022-02-01 [1] CRAN (R 4.1.2)
#>  tidyselect     1.1.2   2022-02-21 [1] CRAN (R 4.1.2)
#>  utf8           1.2.2   2021-07-24 [1] CRAN (R 4.1.2)
#>  vctrs          0.3.8   2021-04-29 [1] CRAN (R 4.1.2)
#>  withr          2.5.0   2022-03-03 [1] CRAN (R 4.1.2)
#>  xfun           0.30    2022-03-02 [1] CRAN (R 4.1.2)
#>  yaml           2.3.5   2022-02-21 [1] CRAN (R 4.1.2)
#> 
#>  [1] C:/Users/Work/Documents/R/win-library/4.1
#>  [2] C:/Program Files/R/R-4.1.2patched/library
#> 
#> ------------------------------------------------------------------------------
```

</details>


SOLUTION:
Adjusted lines 78-93 involved removing the rows of any `X.train`, `X.test` and `t.comp.pred` rows which had an `NA` within them. This is done within the `repeat_cv_j` function such that no data at the global level is lost. Allows cross product to be calculated within inducing any `NA`'s