### PR TITLE
PR addressing Issue #171

### DIFF
--- a/R/pca.R
+++ b/R/pca.R
@@ -250,7 +250,6 @@ pca <- function(X,
         sdev <- res$eig
         loadings <- res$p
     } else {
-        
         if (logratio %in% c('CLR', 'none')) {
             #-- if data is complete use singular value decomposition
             #-- borrowed from 'prcomp' function
@@ -283,7 +282,8 @@ pca <- function(X,
     result <- c(result, .get_var_stats(X = result$X, sdev = result$sdev))
     expected_output_names <- c("call", "X", "ncomp", "center", "scale", "names", 
                          "sdev", "loadings", "variates", "prop_expl_var", "var.tot",
-                         "cum.var")
+                         "cum.var", "rotation", "x")
+    
     if (names(result) %!=% expected_output_names)
     {
         stop("Unexpected error. Please submit an issue at\n",
@@ -318,6 +318,7 @@ pca <- function(X,
              sdev,
              loadings,
              variates = NULL) {
+        
         ncomp <- result$ncomp
         pc_names <- paste("PC", seq_len(ncomp), sep = "")
         
@@ -333,7 +334,12 @@ pca <- function(X,
         dimnames(loadings) = list(colnames(X), pc_names)
         dimnames(variates) = list(rownames(X), pc_names)
         
-        result[c('sdev', 'loadings', 'variates')] <- list(sdev, list(X=loadings), list(X=variates))
+        result[c('sdev', 'loadings', 'variates', 'x', 'rotation')] <- list(sdev, 
+                                                                      list(X=loadings), 
+                                                                      list(X=variates),
+                                                                      variates,
+                                                                      loadings)
+        
         result
     }
 


### PR DESCRIPTION
Despite `cim()` handling `pca` and `spca` object via the same code, their output components are different. This PR adds the `$x` and `$rotation` components to the `pca` object. 

This isn't the cleanest fix as it means there is essentially double ups in the `pca` object. `pca.object$x` are the variates while `pca.object$variates` is the contains the same values but is structured a list of length 1. Downstream functions (such as `network()` and `cim()` access these components differently. Will clean this up in the future