### PR TITLE
Fix for Issue #178

### DIFF
--- a/R/circosPlot.R
+++ b/R/circosPlot.R
@@ -445,6 +445,13 @@ circosPlot.block.splsda <- .circosPlot
 #' @export
 circosPlot.block.spls <- function(object, ..., group = NULL, Y.name = 'Y')
 {
+    # when a block.spls object is supplied that uses the indY parameter, the name
+    # of the object$X component for this dataframe is its proper name
+    # for below checks, change it back to "Y"
+    if (is.null(object$X$Y)) {
+        names(object$X)[object$indY] <- "Y"
+    }
+    
     if (length(group) != nrow(object$X$Y))
         stop("group must be a factor of length: nrow(object$X$Y) = ", nrow(object$X$Y), "\n")
     object$Y <- factor(group)

--- a/tests/testthat/test-circsPlot.R
+++ b/tests/testthat/test-circsPlot.R
@@ -42,3 +42,18 @@ test_that("circosPlot works with similar feature names in different blocks", cod
     expect_is(cp_res, "matrix")
 })
 
+test_that("circosPlot works when using the indY parameter", code = {
+    
+    data("breast.TCGA")
+    data = list(mrna = breast.TCGA$data.train$mrna, 
+                mirna = breast.TCGA$data.train$mirna,
+                protein = breast.TCGA$data.train$protein)
+    
+    list.keepX = list(mrna = rep(20, 2), mirna = rep(10,2), protein = rep(10, 2))
+    TCGA.block.spls = block.spls(X = data, indY = 3, 
+                                     ncomp = 2, keepX = list.keepX, design = 'full')
+    cp_res <- circosPlot(TCGA.block.spls, cutoff = 0.7, group = breast.TCGA$data.train$subtype)
+    
+    expect_is(cp_res, "matrix")
+})
+


### PR DESCRIPTION
Added a check within `circosPlot.block.spls()` (line 451 in `circosPlot.R`). Determines if `object$X$Y` is null (which is the case if `indY` was used in `block.spls()`). If so, changes the name of the `object$X` component which corresponds to the Y dataframe to `Y`. Makes no impact on other plotting functions