### PR TITLE
PR addressing Issue #43

### DIFF
--- a/R/LOGOCV.R
+++ b/R/LOGOCV.R
@@ -263,8 +263,12 @@ LOGOCV <- function(X,
                 })
             }
             
-            # average BER over the study
-            error.mean[[ijk]] = apply(error, 2, mean)
+            # weighted average BER over the studies
+            error.mean[[ijk]] = apply(error, 2, function(x) {
+                sum(x * table(study)/length(study))
+            })
+            
+            
             keepX.opt[[ijk]] =
                 which(error.mean[[ijk]] ==  min(error.mean[[ijk]]))[1]
             

--- a/R/perf.mint.splsda.R
+++ b/R/perf.mint.splsda.R
@@ -218,6 +218,10 @@ perf.mint.plsda <- function (object,
                 auc.mean.study[[comp]][[study_i]] = statauc(data)
             }
             
+            # average of ER and BER across studies, weighted by study sample size
+            global$BER[comp,] <- global$BER[comp,] + study.specific[[study_i]]$BER[comp, ] * table(study)[study_i]/length(study)
+            global$overall[comp,] <- global$overall[comp,] + study.specific[[study_i]]$overall[comp, ] * table(study)[study_i]/length(study)
+            
         } # end study_i 1:M (M folds)
         
         for (ijk in dist)
@@ -226,20 +230,6 @@ perf.mint.plsda <- function (object,
             class.all[[ijk]][,comp] = class.comp[[ijk]][,1]
         }
         prediction.all[[comp]] = prediction.comp
-        
-        
-        # global results
-        #BER
-        global$BER[comp,] = sapply(class.comp, function(x){
-            conf = get.confusion_matrix(truth = factor(Y), predicted = x)
-            get.BER(conf)
-        })
-        
-        #overall
-        global$overall[comp,] = sapply(class.comp, function(x){
-            conf = get.confusion_matrix(truth = factor(Y), predicted = x)
-            out = sum(apply(conf, 1, sum) - diag(conf)) / length(Y)
-        })
         
         #classification for each level of Y
         temp = lapply(class.comp, function(x){

--- a/tests/testthat/test-perf.mint.splsda.R
+++ b/tests/testthat/test-perf.mint.splsda.R
@@ -32,3 +32,34 @@ test_that("perf.mint.splsda works with custom alpha", code = {
     expect_true(all(out$choice.ncomp == 1))
     
 })
+
+test_that("perf.mint.splsda and tune.mint.splsda yield the same error rates for all measures", code = {
+    data(stemcells)
+    X = stemcells$gene
+    Y = stemcells$celltype
+    study <- stemcells$study
+    
+    metricsC1 <- matrix(0, nrow = 2, ncol = 3)
+    colnames(metricsC1) <- c('max.dist', 'centroids.dist', 'mahalanobis.dist')
+    rownames(metricsC1) <- c("overall", "BER")
+    
+    metricsC2 <- metricsC1
+    
+    for (dist in c('max.dist', 'centroids.dist', 'mahalanobis.dist')) {
+        for (measure in c("overall", "BER")) {
+            tune.mint = tune.mint.splsda(X = X, Y = Y, study = study, ncomp = 2, test.keepX = seq(1, 51, 5),
+                                         dist = dist, progressBar = FALSE, measure = measure)
+            
+            mint.splsda.res = mint.splsda(X = X, Y = Y, study = study, ncomp = 2,
+                                          keepX = tune.mint$choice.keepX)
+            
+            perf.mint = perf(mint.splsda.res, progressBar = FALSE, dist = dist)
+            
+            metricsC1[measure, dist] <- tune.mint$error.rate[which(rownames(tune.mint$error.rate) == tune.mint$choice.keepX[1]), "comp1"]
+            metricsC2[measure, dist] <- tune.mint$error.rate[which(rownames(tune.mint$error.rate) == tune.mint$choice.keepX[2]), "comp2"]
+            
+            expect_equal(round(perf.mint$global.error[[measure]]["comp1",], 4), round(metricsC1[[measure, dist]], 4))
+            expect_equal(round(perf.mint$global.error[[measure]]["comp2",], 4), round(metricsC2[[measure, dist]], 4))
+        }
+    }
+})


### PR DESCRIPTION
After extensive exploration, it was determined that the `overall` error rates were consistent across the two functions (`perf.mint.splsda()` and `tune.mint.splsda()`). Hence, only the `BER` calculation needed to be rectified. 

The inconsistency was caused by the way the global BER was calculated in each function:

- `tune.mint.splsda()`: Calculated the confusion matrix of a model *for each study* and then found the mean of these study-specific BER values
- `perf.mint.splsda()`: Calculated the confusion matrix of a model on all samples, irrespective of study. A single BER was yielded from this.

The `perf.mint.splsda()` had its functionality changed such that it was brought in line with the way in which `tune.mint.splsda()` calculated global BER. 

The way in which `global$overall` is calculated in `perf.mint.splsda()` was only adjusted for consistency with `global$BER` - the outputted values in the previous `overall` method and new `overall` method are the same.

A minor addition was made to BOTH functions (in the case of `tune.mint.splsda()`, this occured in `LOGOCV()`). Rather than the global BER being just a basic average of each study-specific BER, both now find the average BER across studies, weighted by the study sample sizes