### PR TITLE
Fix for Issue #192

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -343,9 +343,13 @@ predict.mixo_pls <-
             names(newdata)=names(X)
             
             #check that newdata and X have the same variables
-            if(all.equal(lapply(newdata,colnames),lapply(X,colnames))!=TRUE)
+            if (any(unlist(lapply(seq_along(X), function(i) length(setdiff(colnames(X[[i]]), colnames(newdata[[i]]))) > 0))))
                 stop("Each 'newdata[[i]]' must include all the variables of 'object$X[[i]]'")
             
+            #reorder variables in the newdata as in X if needed
+            if (all.equal(lapply(newdata, colnames), lapply(X, colnames)) != TRUE) {
+                newdata <- setNames(lapply(seq_along(X), function(i) {newdata[[i]][, colnames(X[[i]])]}), nm = names(X))
+            }
             #need to reorder variates and loadings to put 'Y' in last
             if(!is.null(object$indY))
             {

--- a/R/predict.R
+++ b/R/predict.R
@@ -342,9 +342,24 @@ predict.mixo_pls <-
             }
             names(newdata)=names(X)
             
-            #check that newdata and X have the same variables
-            if (any(unlist(lapply(seq_along(X), function(i) length(setdiff(colnames(X[[i]]), colnames(newdata[[i]]))) > 0))))
-                stop("Each 'newdata[[i]]' must include all the variables of 'object$X[[i]]'")
+            #check that newdata and X have the same variables and that they are in the same order
+            for (i in 1:length(newdata)) {
+                X.names <- colnames(X[[i]])
+                newdata.names <- colnames(newdata[[i]])
+                
+                if (any(X.names != newdata.names)) { # if there is any difference between colnames
+                    if (length(setdiff(X.names, newdata.names)) > 0) { # if there is presence of novel feature/absence of existing feature
+                        stop(paste("The set of features in 'object$X$", 
+                                   names(X)[i], "' is different to 'newdata$", 
+                                   names(newdata)[i], "'. Please ensure they have the same features.", sep = ""))
+                    }
+                    else if (all(sort(X.names) == sort(newdata.names))) { # if it is only a difference in order
+                        stop(paste("The order of features in 'object$X$", 
+                                   names(X)[i], "' is different to 'newdata$", 
+                                   names(newdata)[i], "'. Please ensure that you adjust these to the same order", sep = ""))
+                    }
+                }
+            }
             
             #reorder variables in the newdata as in X if needed
             if (all.equal(lapply(newdata, colnames), lapply(X, colnames)) != TRUE) {

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -131,9 +131,16 @@ test_that("predict.block.splsda works on reordered test data", code = {
     predict.diablo = predict(final.diablo.model, newdata = X.test)
     predict.diablo.reordered = predict(final.diablo.model, newdata = X.test.dup)
     
-    for (dist in c("max.dist", "centroids.dist", "mahalanobis.dist")) {
-        for (block in c("mirna", "mrna")) {
-            expect_true(all(predict.diablo$class[[dist]][[block]] == predict.diablo.reordered$class[[dist]][[block]]))
+    homogenity <- matrix(NA, nrow = 2, ncol = 3)
+    colnames(homogenity) <- c("max.dist", "centroids.dist", "mahalanobis.dist")
+    rownames(homogenity) <- c("mirna", "mrna")
+    
+    for (dist in colnames(homogenity)) {
+        for (block in rownames(homogenity)) {
+            homogenity[block, dist] = all(predict.diablo$class[[dist]][[block]] == 
+                                              predict.diablo.reordered$class[[dist]][[block]])
         }
     }
+    
+    expect_true(all(homogenity))
 })

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -97,10 +97,11 @@ test_that("predict.mint.splsda works", code = {
     expect_equal(pred_ref, pred)
 })
 
-
-test_that("predict.block.splsda works on reordered test data", code = {
-    data(breast.TCGA) # load in the data
+test_that("(predict:error): catches when colnames(newdata) differs from colnames(X)", {
     
+    data(breast.TCGA) # load in the data
+
+    # extract data
     X.train = list(mirna = breast.TCGA$data.train$mirna,
                    mrna = breast.TCGA$data.train$mrna)
     
@@ -108,39 +109,88 @@ test_that("predict.block.splsda works on reordered test data", code = {
                   mrna = breast.TCGA$data.test$mrna)
     
     Y.train = breast.TCGA$data.train$subtype
-    Y.test = breast.TCGA$data.test$subtype
     
+    # use optimal values from the case study on mixOmics.org
     optimal.ncomp = 2
     optimal.keepX = list(mirna = c(10,5),
                          mrna = c(26, 16))
     
-    design = matrix(0.1, ncol = length(X.train), nrow = length(X.train), 
+    # set design matrix
+    design = matrix(0.1, ncol = length(X.train), nrow = length(X.train),
                     dimnames = list(names(X.train), names(X.train)))
-    diag(design) = 0 
+    diag(design) = 0
     
+    # generate model
     final.diablo.model = block.splsda(X = X.train, Y = Y.train, ncomp = optimal.ncomp, # set the optimised DIABLO model
                                       keepX = optimal.keepX, design = design)
     
     
     # create new test data with one dataframe being reordered
-    new.var.order = sample(1:dim(X.test$mirna)[2])
+    new.var.order = sample(1:dim(X.test$mrna)[2])
+    X.test.reorder <- X.test
+    X.test.reorder$mrna <- X.test.reorder$mrna[, new.var.order]
     
-    X.test.dup <- X.test
-    X.test.dup$mirna <- X.test.dup$mirna[, new.var.order]
     
-    predict.diablo = predict(final.diablo.model, newdata = X.test)
-    predict.diablo.reordered = predict(final.diablo.model, newdata = X.test.dup)
+    X.test.new.feat <- X.test
+    colnames(X.test.new.feat$mrna)[1] <- "random.feature.name"
     
-    homogenity <- matrix(NA, nrow = 2, ncol = 3)
-    colnames(homogenity) <- c("max.dist", "centroids.dist", "mahalanobis.dist")
-    rownames(homogenity) <- c("mirna", "mrna")
+    # ---------------------------------------------------------------------------- #
     
-    for (dist in colnames(homogenity)) {
-        for (block in rownames(homogenity)) {
-            homogenity[block, dist] = all(predict.diablo$class[[dist]][[block]] == 
-                                              predict.diablo.reordered$class[[dist]][[block]])
-        }
-    }
-    
-    expect_true(all(homogenity))
+    # should raise error about mismatching ORDERS of features
+    expect_error(predict(final.diablo.model, newdata = X.test.reorder),
+                 "The order of features in 'object$X$mrna' is different to 'newdata$mrna'. Please ensure that you adjust these to the same order",
+                 fixed = T)
+
+    # should raise error about mismatching SETS of features
+    expect_error(predict(final.diablo.model, newdata = X.test.new.feat),
+                 "The set of features in 'object$X$mrna' is different to 'newdata$mrna'. Please ensure they have the same features.",
+                 fixed = T)
 })
+
+
+# test_that("predict.block.splsda works on reordered test data", code = {
+#     data(breast.TCGA) # load in the data
+#     
+#     X.train = list(mirna = breast.TCGA$data.train$mirna,
+#                    mrna = breast.TCGA$data.train$mrna)
+#     
+#     X.test = list(mirna = breast.TCGA$data.test$mirna,
+#                   mrna = breast.TCGA$data.test$mrna)
+#     
+#     Y.train = breast.TCGA$data.train$subtype
+#     Y.test = breast.TCGA$data.test$subtype
+#     
+#     optimal.ncomp = 2
+#     optimal.keepX = list(mirna = c(10,5),
+#                          mrna = c(26, 16))
+#     
+#     design = matrix(0.1, ncol = length(X.train), nrow = length(X.train), 
+#                     dimnames = list(names(X.train), names(X.train)))
+#     diag(design) = 0 
+#     
+#     final.diablo.model = block.splsda(X = X.train, Y = Y.train, ncomp = optimal.ncomp, # set the optimised DIABLO model
+#                                       keepX = optimal.keepX, design = design)
+#     
+#     
+#     # create new test data with one dataframe being reordered
+#     new.var.order = sample(1:dim(X.test$mirna)[2])
+#     
+#     X.test.dup <- X.test
+#     X.test.dup$mirna <- X.test.dup$mirna[, new.var.order]
+#     
+#     predict.diablo = predict(final.diablo.model, newdata = X.test)
+#     predict.diablo.reordered = predict(final.diablo.model, newdata = X.test.dup)
+#     
+#     homogenity <- matrix(NA, nrow = 2, ncol = 3)
+#     colnames(homogenity) <- c("max.dist", "centroids.dist", "mahalanobis.dist")
+#     rownames(homogenity) <- c("mirna", "mrna")
+#     
+#     for (dist in colnames(homogenity)) {
+#         for (block in rownames(homogenity)) {
+#             homogenity[block, dist] = all(predict.diablo$class[[dist]][[block]] == 
+#                                               predict.diablo.reordered$class[[dist]][[block]])
+#         }
+#     }
+#     
+#     expect_true(all(homogenity))
+# })

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -96,3 +96,44 @@ test_that("predict.mint.splsda works", code = {
     pred_ref <- readRDS(system.file("testdata", "predict.mint.splsda.rda", package = 'mixOmics'))
     expect_equal(pred_ref, pred)
 })
+
+
+test_that("predict.block.splsda works on reordered test data", code = {
+    data(breast.TCGA) # load in the data
+    
+    X.train = list(mirna = breast.TCGA$data.train$mirna,
+                   mrna = breast.TCGA$data.train$mrna)
+    
+    X.test = list(mirna = breast.TCGA$data.test$mirna,
+                  mrna = breast.TCGA$data.test$mrna)
+    
+    Y.train = breast.TCGA$data.train$subtype
+    Y.test = breast.TCGA$data.test$subtype
+    
+    optimal.ncomp = 2
+    optimal.keepX = list(mirna = c(10,5),
+                         mrna = c(26, 16))
+    
+    design = matrix(0.1, ncol = length(X.train), nrow = length(X.train), 
+                    dimnames = list(names(X.train), names(X.train)))
+    diag(design) = 0 
+    
+    final.diablo.model = block.splsda(X = X.train, Y = Y.train, ncomp = optimal.ncomp, # set the optimised DIABLO model
+                                      keepX = optimal.keepX, design = design)
+    
+    
+    # create new test data with one dataframe being reordered
+    new.var.order = sample(1:dim(X.test$mirna)[2])
+    
+    X.test.dup <- X.test
+    X.test.dup$mirna <- X.test.dup$mirna[, new.var.order]
+    
+    predict.diablo = predict(final.diablo.model, newdata = X.test)
+    predict.diablo.reordered = predict(final.diablo.model, newdata = X.test.dup)
+    
+    for (dist in c("max.dist", "centroids.dist", "mahalanobis.dist")) {
+        for (block in c("mirna", "mrna")) {
+            expect_true(all(predict.diablo$class[[dist]][[block]] == predict.diablo.reordered$class[[dist]][[block]]))
+        }
+    }
+})


### PR DESCRIPTION
This PR is in response to the bug raised by @Ning-L in #192. This PR replaces #193 for consistency's sake.

This commit employs the fix suggested by @Ning-L, such that within the `predict()` function, the similarity of the training and testing variables is tested. If they have the same values but a different order, then they are sorted and algorithm proceeds as normal. The same `stop()` call is raised if they do not contain the exact same set of variables.

Also added a test that ensures that even if one or more of the inputted test dataframes has their variables in a different order to the test set, the same predictions should be made on the novel samples.