### PR TITLE
Fix for Issue #24

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,5 +63,5 @@ biocViews: ImmunoOncology,
            MultipleComparison, 
            Classification, 
            Regression
-RoxygenNote: 7.1.1.9000
+RoxygenNote: 7.1.2
 Encoding: UTF-8

--- a/R/internal_graphicModule.R
+++ b/R/internal_graphicModule.R
@@ -141,9 +141,7 @@ internal_graphicModule <-
         # override if only one pch
         if(nlevels(factor(df$pch)) == 1)
             group.pch = "same"
-        
         #save(list=ls(),file="temp.Rdata")
-        
         #-- Start: ggplot2
         if (style == "ggplot2")
         {
@@ -189,12 +187,13 @@ internal_graphicModule <-
                 p = p + scale_fill_manual(values =
                                               col.vals)
                 
-                if(is.null(xlim))# we choose xlim that fits the points,
-                    #   and not the background
-                    xlim = range(df$x)
-                if(is.null(ylim))# we choose ylim that fits the points,
-                    #   and not the background
-                    ylim = range(df$y)
+                # we choose xlim/ylim that fits the points and the background by finding the
+                # average between the extremes of the two. 
+                # 0.5 then added to min of the lim to prevent any uncoloured area showing
+                if(is.null(xlim))
+                    xlim = (range(df$x) + range(background[, "Var1"]))/2 + c(0.5, 0)
+                if(is.null(ylim))
+                    ylim = (range(df$y) + range(background[, "Var2"]))/2 + c(0.5, 0)
             }
             
             #-- Display sample or row.names
@@ -478,6 +477,34 @@ internal_graphicModule <-
                                       color = unique(col.per.group)[i], size = point.lwd,
                                       inherit.aes =FALSE)
                 }
+            }
+            
+            if(!is.null(background))
+            {
+                for(i in 1:length(background))
+                {
+                    if(!is.null(background[[i]]))
+                        background[[i]]=data.frame(id=i,col=names(background)[i],
+                                                   background[[i]])
+                }
+                
+                background = do.call(rbind,background)
+                
+                p = p+geom_polygon(data = background,aes(x=Var1, y=Var2,
+                                                         fill = col), inherit.aes = FALSE, show.legend
+                                   =FALSE)
+                col.vals <- as.character(unique(background$col))
+                names(col.vals) <- col.vals
+                p = p + scale_fill_manual(values =
+                                              col.vals)
+                
+                # we choose xlim/ylim that fits the points and the background by finding the
+                # average between the extremes of the two. 
+                # 0.5 then added to min of the lim to prevent any uncoloured area showing
+                if(is.null(xlim))
+                    xlim = (range(df$x) + range(background[, "Var1"]))/2 + c(0.5, 0)
+                if(is.null(ylim))
+                    ylim = (range(df$y) + range(background[, "Var2"]))/2 + c(0.5, 0)
             }
             
             plot(p)

--- a/R/internal_mint.block_helpers.R
+++ b/R/internal_mint.block_helpers.R
@@ -311,14 +311,13 @@ mean_centering_per_study <- function(data, study, scale)
                 attr(concat.data,paste0("sigma:", levels(study)[m])) = NULL
             }
         }
+    } 
+    attr(concat.data,"scaled:center") = meanX[[1]]
+    if (scale)
+    {
+        attr(concat.data,"scaled:scale") = sqrt.sdX[[1]]
     } else {
-        attr(concat.data,"scaled:center") = meanX[[1]]
-        if (scale)
-        {
-            attr(concat.data,"scaled:scale") = sqrt.sdX[[1]]
-        } else {
-            attr(concat.data,"scaled:scale") = NULL
-        }
+        attr(concat.data,"scaled:scale") = NULL
     }
     
     return(list(concat.data=concat.data, rownames.study=rownames.study))

--- a/R/plotIndiv.mint.R
+++ b/R/plotIndiv.mint.R
@@ -40,6 +40,7 @@ plotIndiv.mint.pls <-
              legend.title = "Legend",
              legend.position = "right",
              point.lwd = 1,
+             background = NULL,
              ...
              
     )
@@ -364,6 +365,12 @@ plotIndiv.mint.pls <-
         if (style == "ggplot2")
             style = "ggplot2-MINT"
         
+        if(!is.null(background))
+        {
+            ind.match = match(names(background), levels(df$group))
+            names(background) = adjustcolor(col.per.group[ind.match],alpha.f=0.1)
+        }
+        
         #call plot module (ggplot2, lattice, graphics, 3d)
         res = internal_graphicModule(
             df = df,
@@ -383,6 +390,7 @@ plotIndiv.mint.pls <-
             df.ellipse = df.ellipse,
             style = style,
             layout = layout,
+            background = background,
             #missing.col = missing.col,
             #for ggplot2-MINT
             study.levels = study.levels,

--- a/man/plotIndiv.Rd
+++ b/man/plotIndiv.Rd
@@ -49,6 +49,7 @@ plotIndiv(object, ...)
   legend.title = "Legend",
   legend.position = "right",
   point.lwd = 1,
+  background = NULL,
   ...
 )
 
@@ -86,6 +87,7 @@ plotIndiv(object, ...)
   legend.title = "Legend",
   legend.position = "right",
   point.lwd = 1,
+  background = NULL,
   ...
 )
 
@@ -123,6 +125,7 @@ plotIndiv(object, ...)
   legend.title = "Legend",
   legend.position = "right",
   point.lwd = 1,
+  background = NULL,
   ...
 )
 
@@ -160,6 +163,7 @@ plotIndiv(object, ...)
   legend.title = "Legend",
   legend.position = "right",
   point.lwd = 1,
+  background = NULL,
   ...
 )
 
@@ -438,6 +442,9 @@ is not "global"}
 \item{point.lwd}{\code{lwd} of the points, used when \code{ind.names =
 FALSE}}
 
+\item{background}{color the background by the predicted class, see
+\code{\link{background.predict}}}
+
 \item{ind.names}{either a character vector of names for the individuals to
 be plotted, or \code{FALSE} for no names. If \code{TRUE}, the row names of
 the first (or second) data matrix is used as names (see Details).}
@@ -455,9 +462,6 @@ for the legend.}
 
 \item{legend.title.pch}{title of the second legend created by \code{pch}, if
 any.}
-
-\item{background}{color the background by the predicted class, see
-\code{\link{background.predict}}}
 
 \item{blocks}{integer value or name(s) of block(s) to be plotted using the
 GCCA module. "average" and "weighted.average" will create average and

--- a/tests/testthat/test-plotIndiv.R
+++ b/tests/testthat/test-plotIndiv.R
@@ -43,6 +43,19 @@ test_that("plotIndiv works for (s)plsda", {
   .expect_numerically_close(pl.res$graph$data$x[1], -1.075222)
 })
 
+test_that("plotIndiv works for (s)plsda with background", {
+  data(breast.tumors)
+  X <- breast.tumors$gene.exp
+  Y <- breast.tumors$sample$treatment
+  
+  splsda.breast <- splsda(X, Y,keepX=c(10,10),ncomp=2)
+  bg <- background.predict(splsda.breast, comp.predicted = 2, 
+                           dist = "max.dist")
+  
+  pl.res <- plotIndiv(splsda.breast, background = bg)
+  .expect_numerically_close(pl.res$graph$data$x[1], -1.075222)
+})
+
 ## ------------------------------------------------------------------------ ##
 test_that("plotIndiv works for (s)pls", {
   data(liver.toxicity)
@@ -131,6 +144,42 @@ test_that("plotIndiv.sgcca(..., blocks = 'average') works", code = {
     expect_true(any(grepl(pattern = "average", x = unique(plotindiv_res$df$Block))))
 })
 
+## ------------------------------------------------------------------------ ##
+
+test_that("plotIndiv.mint works", code = {
+  data(srbct)
+  
+  stnd.res.srbct <- splsda(X = srbct$gene, Y = srbct$class, ncomp = 3)
+  
+  pl.res <- plotIndiv(stnd.res.srbct, legend = T, style = "ggplot2")
+  .expect_numerically_close(pl.res$graph$data$x[1], -6.83832)
+})
+
+
+
+test_that("plotIndiv.mint works with background input (all distances)", code = {
+  data(stemcells)
+  
+  mint.res.stem <- mint.splsda(X = stemcells$gene, Y = stemcells$celltype, ncomp = 4,
+                               study = stemcells$study)
+  
+  distances <- c("max.dist", "centroids.dist", "mahalanobis.dist")
+  truePoints <- list(c(7.795485, 5.947594),
+                     c(5.285750, 6.534955),
+                     c(4.568683, 7.905465))
+  
+  for (i in 1:3) {
+    mint.bg.stem = background.predict(mint.res.stem, comp.predicted = 2, # raises error found in #24 on GitHub
+                                          dist = distances[i])
+    .expect_numerically_close(unname(mint.bg.stem$hiPSC[150,]), truePoints[[i]])
+  }
+  
+  pl.res <- plotIndiv(mint.res.stem, background = mint.bg.stem, legend = T, style = "ggplot2")
+  .expect_numerically_close(pl.res$graph$data$x[1], -4.167696)
+  
+})
+  
+  
 ## ------------------------------------------------------------------------ ##
 
 test_that("plotIndiv.sgccda(..., blocks = 'average') works with ind.names and ell", code = {


### PR DESCRIPTION
This issue ended up being more multifaceted than originally thought. 

***--- Prior issue: ---***
While exploring the bug, a separate (but related) issue was noticed. On standard `(s)plsda` objects (ie. non-MINT), only some of the `background.predict()` regions (or polygons) would display. Only thing that resolved this issue was manually adjusting the `xlim` and `ylim` parameters (increasing their bounds). This occured only for `style = ggplot2`. The `ggplot2` package entirely removes polygons from the plot if a certain percentage of said polygon is outside the range of the axes (ie, if plot too zoomed in, polygon won't show). Previously `internal_graphicModule()` had used the bounds of the points as the default `xlim` and `ylim`, resulting in this cutoff.

Hence, to resolve this, if a background is supplied (and `xlim`/`ylim` are not supplied) to `plotIndiv()`, then the default value of the limit parameters is set to the average of the minimum/maximum values of the points and the polygons. This allows the plot to not be too 'zoomed out' as well as the polygons to be shown.

***--- Immediate Issue: ---***
The error raised when trying to use `dist = "max.dist"` in `background.predict()` on a `mint.splsda` object was caused by the absence of the `center` and `scale` attributes on the `mint.splsda$ind.mat` object. It had these for each study individually, but global values are needed for `background.predict()`. Using the follow externally would result in incorrect values for these attributes: 
`mint.res.object$ind.mat <- scale(mint.res.object$ind.mat)`

Hence, `mean_centering_per_study()` was adjusted such that if the `center` and `scale`  parameters were `TRUE`, irrespective of whether it is a MINT object or not, the global `center` and `scale` attributes will be appended to the `ind.mat` object.

***--- Downstream issue: ---***
The above fix resolved the error noted in Issue #24, however upon using the `plotIndiv()` function with a supplied background (on the `mint.splsda` object), no background would be shown. This was due to the absence of any code which handles background polygons within the `if (style == "ggplot2-MINT")` block (starts on line 364 of `internal_graphicModule()`). 

Hence, the code from the `if (style == "ggplot2")` which handles backgrounds was copied over into the MINT block. On top of this, `plotIndiv.mint()` was slightly adjusted so the `names(background.object)` are converted into colours. This is how it is handled in the standard sPLSDA case so this process was homogenised for consistency's sake.