### PR TITLE
Fix for issue #162: Replace is() with inherits when class2 is a vector

### DIFF
--- a/R/S3methods-print.R
+++ b/R/S3methods-print.R
@@ -614,7 +614,7 @@ print.summary <-
         digits = x$digits
         
         #--------------------- output pls/spls ---------------------#
-        if(is(x, c("pls", "spls"))){
+        if(inherits(x, c("pls", "spls"))){
             
             if (is(x, "pls"))
             {

--- a/R/plotIndiv.pls.R
+++ b/R/plotIndiv.pls.R
@@ -52,11 +52,11 @@ plotIndiv.mixo_pls <-
                                size.axis = size.axis, size.legend = size.legend, size.legend.title = size.legend.title, legend.title = legend.title,
                                legend.title.pch = legend.title.pch, legend.position = legend.position, point.lwd = point.lwd)
         
-        if (is(object, c("mint.block.pls", "mint.block.spls", "mint.block.plsda", "mint.block.splsda")))
+        if (inherits(object, c("mint.block.pls", "mint.block.spls", "mint.block.plsda", "mint.block.splsda")))
             stop("No plotIndiv for the following functions at this stage: mint.block.pls, mint.block.spls, mint.block.plsda, mint.block.splsda.")
         
         #-- choose rep.space
-        if (is.null(rep.space) && is(object, "DA"))#"splsda", "plsda", "mlsplsda")))
+        if (is.null(rep.space) && inherits(object, "DA"))#"splsda", "plsda", "mlsplsda")))
         {
             rep.space = "X-variate"
         } else if (is.null(rep.space)) {

--- a/R/plotLoadings.R
+++ b/R/plotLoadings.R
@@ -956,7 +956,7 @@ check.input.plotLoadings <- function(object,
         if (!is(object, "DA"))
         {
             block = object$names$blocks
-        } else  if (is(object, c("mixo_plsda", "mixo_splsda"))) {
+        } else  if (inherits(object, c("mixo_plsda", "mixo_splsda"))) {
             block = "X"
         } else {
             if (!is.null(object$indY))
@@ -968,13 +968,13 @@ check.input.plotLoadings <- function(object,
         }
     }
     
-    if (is(object, c("mixo_plsda", "mixo_splsda")) & (!all(block %in% c(1,"X")) | length(block) > 1 ))
+    if (inherits(object, c("mixo_plsda", "mixo_splsda")) & (!all(block %in% c(1,"X")) | length(block) > 1 ))
         stop("'block' can only be 'X' or '1' for plsda and splsda object")
     
-    if (is(object, c("mixo_plsda", "mixo_splsda","pca")))
+    if (inherits(object, c("mixo_plsda", "mixo_splsda","pca")))
     {
         object$indY = 2
-    } else if (is(object, c("mixo_pls", "mixo_spls"))) {
+    } else if (inherits(object, c("mixo_pls", "mixo_spls"))) {
         object$indY = 3 # we don't want to remove anything in that case, and 3 is higher than the number of blocks which is 2
     }
     
@@ -1189,7 +1189,7 @@ get.loadings.ndisplay <- function(object,
     
     #comp
     # ----
-    if (is(object, c("mixo_pls","mixo_spls", "rcc")))# cause pls methods just have 1 ncomp, block approaches have different ncomp per block
+    if (inherits(object, c("mixo_pls","mixo_spls", "rcc")))# cause pls methods just have 1 ncomp, block approaches have different ncomp per block
     {
         ncomp = object$ncomp
         object$X = list(X = object$X, Y = object$Y) # so that the data is in object$X, either it's a pls or block approach

--- a/R/predict.R
+++ b/R/predict.R
@@ -185,7 +185,7 @@ predict.mixo_pls <-
         
         # input parameter: noAveragePredict=> no averagePredict calculation, used in tune.block.splsda
         
-        if(is(object, c("rgcca","sparse.rgcca")))
+        if(inherits(object, c("rgcca","sparse.rgcca")))
             stop("no prediction for RGCCA methods")
         
         #check on dist
@@ -223,7 +223,7 @@ predict.mixo_pls <-
         mint.object = c("mint.pls", "mint.spls", "mint.plsda", "mint.splsda")
         block.object = c("block.pls", "block.spls", "block.plsda", "block.splsda")
         ### if the object is a block, the input newdata is different, we check newdata, make sure it's a list and check newdata/X
-        if(!is(object, block.object)) # not a block (pls/spls/plsda/splsda/mint...)
+        if(!inherits(object, block.object)) # not a block (pls/spls/plsda/splsda/mint...)
         {
             p=ncol(object$X)
             if(is.list(object$X))
@@ -624,7 +624,7 @@ predict.mixo_pls <-
         if(time) time4 = proc.time()
         
         # basic prediction results
-        if(is(object, block.object) & length(object$X)>1 )
+        if(inherits(object, block.object) & length(object$X)>1 )
         {
             out=list(predict=Y.hat[which(!is.na(ind.match))],variates=t.pred[which(!is.na(ind.match))],B.hat=B.hat[which(!is.na(ind.match))])
             


### PR DESCRIPTION
This pull request fixes failures on R-devel 4.2 as described on:

- #162 

I basically replace `is()` with `inherits()` when `class2` is a vector

This is the R source commit where `is()` became more stringent (January 2022):

- https://github.com/wch/r-source/commit/e0fa9f347ed70a650d8842a2a00046acc6ce4f43

Looking forward for a merge, since some other packages I maintain fail because of this error in bioconductor.

Thanks for your time!