### PR TITLE
Enhancement for #111

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,5 +63,5 @@ biocViews: ImmunoOncology,
            MultipleComparison, 
            Classification, 
            Regression
-RoxygenNote: 7.1.1.9000
+RoxygenNote: 7.1.2
 Encoding: UTF-8

--- a/R/MCV.block.splsda.R
+++ b/R/MCV.block.splsda.R
@@ -331,7 +331,7 @@ MCVfold.block.splsda <-
                         test.keepX=test.keepX, test.keepY=ncol(Y.train.mat),
                         mode="regression", scale=scale, near.zero.var=near.zero.var,
                         design=design, max.iter=max.iter, scheme =scheme, init=init,
-                        tol=tol,
+                        tol=tol, DA = TRUE,
                         misdata = misdata, is.na.A = is.na.A.temp, ind.NA = ind.NA.temp,
                         ind.NA.col = ind.NA.col.temp, all.outputs=FALSE))
                 

--- a/R/MCV.block.splsda.R
+++ b/R/MCV.block.splsda.R
@@ -475,7 +475,7 @@ MCVfold.block.splsda <-
             return(list(class.comp.rep=class.comp.rep, keepA=keepA))
         } #end nrep 1:nrepeat
         
-        class.comp.reps <- bplapply(seq_len(nrepeat), repeat_cv, all_folds = all_folds, M = M) # , BPPARAM = BPPARAM
+        class.comp.reps <- bplapply(seq_len(nrepeat), repeat_cv, all_folds = all_folds, M = M, BPPARAM = BPPARAM)
  
         list2array <- function(cc) {
             ## function to make an array of results of all repeats ino the former form

--- a/R/MCV.block.splsda.R
+++ b/R/MCV.block.splsda.R
@@ -475,8 +475,8 @@ MCVfold.block.splsda <-
             return(list(class.comp.rep=class.comp.rep, keepA=keepA))
         } #end nrep 1:nrepeat
         
-        class.comp.reps <- bplapply(seq_len(nrepeat), repeat_cv, all_folds = all_folds, M = M, BPPARAM = BPPARAM)
-
+        class.comp.reps <- bplapply(seq_len(nrepeat), repeat_cv, all_folds = all_folds, M = M) # , BPPARAM = BPPARAM
+ 
         list2array <- function(cc) {
             ## function to make an array of results of all repeats ino the former form
             ## before nrepeat loop becomes a function

--- a/R/block.pls.R
+++ b/R/block.pls.R
@@ -105,7 +105,7 @@ block.pls <- function(X,
     result = internal_wrapper.mint.block(X=X, Y=Y, indY=indY, ncomp=ncomp,
                                          design=design, scheme=scheme, mode=mode, scale=scale,
                                          init=init, tol=tol, max.iter=max.iter ,near.zero.var=near.zero.var,
-                                         all.outputs = all.outputs)
+                                         all.outputs = all.outputs, DA = FALSE)
     
     # calculate weights for each dataset
     weights = get.weights(result$variates, indY = result$indY)

--- a/R/block.plsda.R
+++ b/R/block.plsda.R
@@ -104,10 +104,10 @@ block.plsda <- function(X,
     # check inpuy 'Y' and transformation in a dummy matrix
     if (!missing(Y))
     {
-        if (is.null(dim(Y)))
-        {
+        if (is.null(dim(Y))) {
             Y = factor(Y)
-        } else {
+        } 
+        else {
             stop("'Y' should be a factor or a class vector.")
         }
         
@@ -154,7 +154,8 @@ block.plsda <- function(X,
         tol = tol,
         max.iter = max.iter,
         near.zero.var = near.zero.var,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        DA = TRUE
     )
     
     # calculate weights for each dataset

--- a/R/block.spls.R
+++ b/R/block.spls.R
@@ -120,7 +120,8 @@ block.spls = function(X,
         tol = tol,
         max.iter = max.iter,
         near.zero.var = near.zero.var,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        DA = FALSE
     )
     
     # calculate weights for each dataset

--- a/R/check_entry.R
+++ b/R/check_entry.R
@@ -203,8 +203,18 @@ Check.entry.pls = function(X, Y, ncomp, keepX, keepY, test.keepX, test.keepY,
         stop("Choose one of the two following logratio transformation: none or CLR")
     
     # if DA and the unmapped Y has rows without associated class
-    if (DA & length(which(rowSums(Y)==0)) != 0) {
-        stop("Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector")
+    if (DA) {
+        Y.tmp <- NULL
+        if (missing(Y)) {
+            Y.tmp <- X[[indY]]
+        } else {
+            Y.tmp <- Y
+        }
+        
+        if (length(which(rowSums(Y.tmp)==0)) != 0) {
+            stop("Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector")
+        }
+        rm(Y.tmp)
     }
     
     if(!is.null(multilevel))

--- a/R/check_entry.R
+++ b/R/check_entry.R
@@ -467,8 +467,18 @@ Check.entry.wrapper.mint.block = function(X,
         stop("Either 'Y' or 'indY' is needed")
     
     # if DA and the unmapped Y has rows without associated class
-    if (DA & length(which(rowSums(Y)==0)) != 0) {
-        stop("Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector")
+    if (DA) {
+        Y.tmp <- NULL
+        if (missing(Y)) {
+            Y.tmp <- X[[indY]]
+        } else {
+            Y.tmp <- Y
+        }
+        
+        if (length(which(rowSums(Y.tmp)==0)) != 0) {
+            stop("Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector")
+        }
+        rm(Y.tmp)
     }
     
     if (missing(ncomp))

--- a/R/check_entry.R
+++ b/R/check_entry.R
@@ -202,6 +202,11 @@ Check.entry.pls = function(X, Y, ncomp, keepX, keepY, test.keepX, test.keepY,
     if (!(logratio %in% c("none", "CLR")))
         stop("Choose one of the two following logratio transformation: none or CLR")
     
+    # if DA and the unmapped Y has rows without associated class
+    if (DA & length(which(rowSums(Y)==0)) != 0) {
+        stop("Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector")
+    }
+    
     if(!is.null(multilevel))
     {
         #multilevel analysis: withinVariation and then pls-like
@@ -460,6 +465,11 @@ Check.entry.wrapper.mint.block = function(X,
     
     if ((missing(indY) & missing(Y)))
         stop("Either 'Y' or 'indY' is needed")
+    
+    # if DA and the unmapped Y has rows without associated class
+    if (DA & length(which(rowSums(Y)==0)) != 0) {
+        stop("Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector")
+    }
     
     if (missing(ncomp))
         ncomp = 1

--- a/R/internal_wrapper.mint.R
+++ b/R/internal_wrapper.mint.R
@@ -205,7 +205,7 @@ internal_wrapper.mint <-
                                  ncomp = c(ncomp, ncomp), tol = tol, max.iter = max.iter,
                                  design = design, keepA = keepA, scale = scale, scheme = "horst",init="svd",
                                  study = study, misdata = misdata, is.na.A = is.na.A, ind.NA = ind.NA,
-                                 ind.NA.col = ind.NA.col, all.outputs= all.outputs, remove.object=c("X"))
+                                 ind.NA.col = ind.NA.col, all.outputs= all.outputs, remove.object=c("X"), DA = DA)
     
     #-- pls approach ----------------------------------------------------#
     #--------------------------------------------------------------------------#

--- a/R/internal_wrapper.mint.R
+++ b/R/internal_wrapper.mint.R
@@ -205,7 +205,7 @@ internal_wrapper.mint <-
                                  ncomp = c(ncomp, ncomp), tol = tol, max.iter = max.iter,
                                  design = design, keepA = keepA, scale = scale, scheme = "horst",init="svd",
                                  study = study, misdata = misdata, is.na.A = is.na.A, ind.NA = ind.NA,
-                                 ind.NA.col = ind.NA.col, all.outputs= all.outputs, remove.object=c("X"), DA = DA)
+                                 ind.NA.col = ind.NA.col, all.outputs= all.outputs, remove.object=c("X"))
     
     #-- pls approach ----------------------------------------------------#
     #--------------------------------------------------------------------------#

--- a/R/internal_wrapper.mint.block.R
+++ b/R/internal_wrapper.mint.block.R
@@ -70,7 +70,7 @@ internal_wrapper.mint.block <-
         
         # checks (near.zero.var is done there)
         check <- Check.entry.wrapper.mint.block(X = X, Y = Y, indY = indY,
-                                             ncomp = ncomp, keepX = keepX, keepY = keepY, DA=DA,
+                                             ncomp = ncomp, keepX = keepX, keepY = keepY, DA = DA,
                                              study = study, design = design, init = init, scheme = scheme, scale = scale,
                                              near.zero.var = near.zero.var, mode = mode, tol = tol,
                                              max.iter = max.iter)

--- a/R/mint.block.pls.R
+++ b/R/mint.block.pls.R
@@ -125,7 +125,8 @@ mint.block.pls <- function(X,
         tol = tol,
         max.iter = max.iter,
         near.zero.var = near.zero.var,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        DA = FALSE
     )
     
     # choose the desired output from 'result'

--- a/R/mint.block.plsda.R
+++ b/R/mint.block.plsda.R
@@ -196,7 +196,8 @@ mint.block.plsda <- function(X,
         tol = tol,
         max.iter = max.iter,
         near.zero.var = near.zero.var,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        DA = TRUE
     )
     
     # choose the desired output from 'result'

--- a/R/mint.block.spls.R
+++ b/R/mint.block.spls.R
@@ -121,7 +121,8 @@ mint.block.spls <- function(X,
         tol = tol,
         max.iter = max.iter,
         near.zero.var = near.zero.var,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        DA = FALSE
     )
     
     # choose the desired output from 'result'

--- a/R/mint.block.splsda.R
+++ b/R/mint.block.splsda.R
@@ -169,7 +169,8 @@ mint.block.splsda <- function(X,
         tol = tol,
         max.iter = max.iter,
         near.zero.var = near.zero.var,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        DA = TRUE
     )
     
     # choose the desired output from 'result'

--- a/R/mint.pls.R
+++ b/R/mint.pls.R
@@ -115,7 +115,8 @@ mint.pls <- function(X,
         mode = mode,
         max.iter = max.iter,
         tol = tol,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        DA = FALSE
     )
     
     # choose the desired output from 'result'

--- a/R/mint.plsda.R
+++ b/R/mint.plsda.R
@@ -144,7 +144,8 @@ mint.plsda <- function(X,
         mode = 'regression',
         max.iter = max.iter,
         tol = tol,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        DA = TRUE
     )
     
     # choose the desired output from 'result'

--- a/R/mint.spls.R
+++ b/R/mint.spls.R
@@ -131,7 +131,8 @@ mint.spls <- function(X,
         keepY = keepY,
         max.iter = max.iter,
         tol = tol,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        DA = FALSE
     )
     
     # choose the desired output from 'result'

--- a/R/mint.splsda.R
+++ b/R/mint.splsda.R
@@ -150,7 +150,8 @@ mint.splsda <- function(X,
         max.iter = max.iter,
         tol = tol,
         scale = scale,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        DA = TRUE
     )
     
     # choose the desired output from 'result'

--- a/tests/testthat/test-general.DA.R
+++ b/tests/testthat/test-general.DA.R
@@ -1,0 +1,53 @@
+context("general.DA")
+
+test_that("ALL DA functions raise specific error when Y contains NAs", {
+  
+  data(srbct)
+  X <- srbct$gene
+  Y <- srbct$class
+  Y[c(1,2,3)] <- NA
+  
+  data("breast.TCGA")
+  X.b <- list(mirna = breast.TCGA$data.train$mirna,
+              mrna = breast.TCGA$data.train$mrna)
+  Y.b <- breast.TCGA$data.train$subtype
+  Y.b[c(1,2,3)] <- NA
+  
+  data("stemcells")
+  X.m <- stemcells$gene
+  Y.m <- stemcells$celltype
+  Y.m[c(1,2,3)] <- NA
+  S.m <- stemcells$study
+  
+  # ------------------------------------------------------------------------- #
+  
+  # plsda - needs work
+  expect_error(plsda(X, Y), 
+               "Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector", 
+               fixed = TRUE)
+  
+  # splsda - needs work
+  expect_error(plsda(X, Y), 
+               "Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector", 
+               fixed = TRUE)
+  
+  # block.plsda
+  expect_error(block.plsda(X.b, Y.b), 
+               "Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector", 
+               fixed = TRUE)
+  
+  # block.splsda
+  expect_error(block.splsda(X.b, Y.b), 
+               "Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector", 
+               fixed = TRUE)
+  
+  # mint.plsda
+  expect_error(mint.plsda(X.m, Y.m, study = S.m), 
+               "Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector", 
+               fixed = TRUE)
+  
+  # mint.splsda
+  expect_error(mint.splsda(X.m, Y.m, study = S.m), 
+               "Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector", 
+               fixed = TRUE)
+})

--- a/tests/testthat/test-general.DA.R
+++ b/tests/testthat/test-general.DA.R
@@ -12,6 +12,7 @@ test_that("ALL DA functions raise specific error when Y contains NAs", {
               mrna = breast.TCGA$data.train$mrna)
   Y.b <- breast.TCGA$data.train$subtype
   Y.b[c(1,2,3)] <- NA
+  Y.b.2 <- breast.TCGA$data.train$protein
   
   data("stemcells")
   X.m <- stemcells$gene
@@ -21,12 +22,12 @@ test_that("ALL DA functions raise specific error when Y contains NAs", {
   
   # ------------------------------------------------------------------------- #
   
-  # plsda - needs work
+  # plsda
   expect_error(plsda(X, Y), 
                "Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector", 
                fixed = TRUE)
   
-  # splsda - needs work
+  # splsda
   expect_error(plsda(X, Y), 
                "Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector", 
                fixed = TRUE)
@@ -50,4 +51,10 @@ test_that("ALL DA functions raise specific error when Y contains NAs", {
   expect_error(mint.splsda(X.m, Y.m, study = S.m), 
                "Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector", 
                fixed = TRUE)
+  
+  # block.pls - ensure no error is raised for regression type problem
+  expect_is(block.pls(X.b, Y.b.2), "block.pls")
+  
+  # block.spls - ensure no error is raised for regression type problem
+  expect_is(block.spls(X.b, Y.b.2), "block.spls")
 })


### PR DESCRIPTION
enhancement(DA): provided a more informative error message when a Y vector containing NAs is passed to any DA method

Added a check within `Check.entry.pls()` and `Check.entry.wrapper.mint.block()` which checks if discriminant analysis is being done and if unmapped Y dataframe has any rows which sum to 0 (no associated class). If so, stops with specific error message.

Added `DA = TRUE` to `internal_wrapper.mint()` calls in `block.splsda()`, `mint.plsda()` and `mint.splsda()` so that the new checks will be engaged.

Removed the `BPPARAM` parameter from the `repeat_cv()` call in `MCVfold.block.splsda()` as this was raising an error in the tests. Functionality is seemingly unaffected