### PR TITLE
Remaining fix for #162

### DIFF
--- a/R/S3methods-print.R
+++ b/R/S3methods-print.R
@@ -614,7 +614,7 @@ print.summary <-
         digits = x$digits
         
         #--------------------- output pls/spls ---------------------#
-        if(is(x, c("pls", "spls"))){
+        if(inherits(x, c("pls", "spls"))){
             
             if (is(x, "pls"))
             {


### PR DESCRIPTION
Hi @aljabadi 

There is at one more usage of `is()` that should be `inherits()`.

Closes #169. Related to #199, #208.