### PR TITLE
Updated fix for Isssue #120

### DIFF
--- a/R/plotLoadings.R
+++ b/R/plotLoadings.R
@@ -532,7 +532,7 @@ plotLoadings.mint.pls <-
         if(any(study == "global"))
         {
             # if study == "global" then we plot the results on the concatenated data, thus direct call to plotLoadings.plsda
-            plotLoadings.mixo_pls(object = object, block = "X", comp = comp, ndisplay = ndisplay,
+            plotLoadings.mixo_pls(object = object, block = c("X", "Y"), comp = comp, ndisplay = ndisplay,
                                   size.name = size.name,
                                   name.var = name.var,
                                   name.var.complete = name.var.complete,
@@ -549,11 +549,11 @@ plotLoadings.mint.pls <-
             # if study != "global" then we plot the results on each study
             
             # -- input checks
-            check = check.input.plotLoadings(object = object, block = "X", title = title, col = col, size.name = size.name, name.var = name.var)
+            check = check.input.plotLoadings(object = object, block = c("X", "Y"), title = title, col = col, size.name = size.name, name.var = name.var)
             
             col = check$col
             size.name = check$size.name
-            block = check$block # "X"
+            block = check$block # c("X", "Y")
             
             #study needs to be either: from levels(object$study), numbers from 1:nlevels(study) or "global"
             if (any(!study%in%c(levels(object$study), "global" , "all.partial")))
@@ -970,7 +970,7 @@ check.input.plotLoadings <- function(object,
         if (!is(object, "DA"))
         {
             block = object$names$blocks
-        } else  if (is(object, c("mixo_plsda", "mixo_splsda"))) {
+        } else  if (inherits(object, c("mixo_plsda", "mixo_splsda"))) {
             block = "X"
         } else {
             if (!is.null(object$indY))
@@ -982,13 +982,13 @@ check.input.plotLoadings <- function(object,
         }
     }
     
-    if (is(object, c("mixo_plsda", "mixo_splsda")) & (!all(block %in% c(1,"X")) | length(block) > 1 ))
+    if (inherits(object, c("mixo_plsda", "mixo_splsda")) & (!all(block %in% c(1,"X")) | length(block) > 1 ))
         stop("'block' can only be 'X' or '1' for plsda and splsda object")
     
-    if (is(object, c("mixo_plsda", "mixo_splsda","pca")))
+    if (inherits(object, c("mixo_plsda", "mixo_splsda","pca")))
     {
         object$indY = 2
-    } else if (is(object, c("mixo_pls", "mixo_spls"))) {
+    } else if (inherits(object, c("mixo_pls", "mixo_spls"))) {
         object$indY = 3 # we don't want to remove anything in that case, and 3 is higher than the number of blocks which is 2
     }
     
@@ -1203,7 +1203,7 @@ get.loadings.ndisplay <- function(object,
     
     #comp
     # ----
-    if (is(object, c("mixo_pls","mixo_spls", "rcc")))# cause pls methods just have 1 ncomp, block approaches have different ncomp per block
+    if (inherits(object, c("mixo_pls","mixo_spls", "rcc")))# cause pls methods just have 1 ncomp, block approaches have different ncomp per block
     {
         ncomp = object$ncomp
         object$X = list(X = object$X, Y = object$Y) # so that the data is in object$X, either it's a pls or block approach

--- a/R/plotLoadings.R
+++ b/R/plotLoadings.R
@@ -549,7 +549,7 @@ plotLoadings.mint.pls <-
             # if study != "global" then we plot the results on each study
             
             # -- input checks
-            check = check.input.plotLoadings(object = object, block = c("X", "Y"), title = title, col = col, size.name = size.name, name.var = name.var)
+            check = check.input.plotLoadings(object = object, block = c("X", "Y"), study = study, title = title, col = col, size.name = size.name, name.var = name.var)
             
             col = check$col
             size.name = check$size.name
@@ -970,7 +970,7 @@ check.input.plotLoadings <- function(object,
         if (!is(object, "DA"))
         {
             block = object$names$blocks
-        } else  if (inherits(object, c("mixo_plsda", "mixo_splsda"))) {
+        } else  if (is(object, c("mixo_plsda", "mixo_splsda"))) {
             block = "X"
         } else {
             if (!is.null(object$indY))
@@ -982,13 +982,13 @@ check.input.plotLoadings <- function(object,
         }
     }
     
-    if (inherits(object, c("mixo_plsda", "mixo_splsda")) & (!all(block %in% c(1,"X")) | length(block) > 1 ))
+    if (is(object, c("mixo_plsda", "mixo_splsda")) & (!all(block %in% c(1,"X")) | length(block) > 1 ))
         stop("'block' can only be 'X' or '1' for plsda and splsda object")
     
-    if (inherits(object, c("mixo_plsda", "mixo_splsda","pca")))
+    if (is(object, c("mixo_plsda", "mixo_splsda","pca")))
     {
         object$indY = 2
-    } else if (inherits(object, c("mixo_pls", "mixo_spls"))) {
+    } else if (is(object, c("mixo_pls", "mixo_spls"))) {
         object$indY = 3 # we don't want to remove anything in that case, and 3 is higher than the number of blocks which is 2
     }
     
@@ -1203,7 +1203,7 @@ get.loadings.ndisplay <- function(object,
     
     #comp
     # ----
-    if (inherits(object, c("mixo_pls","mixo_spls", "rcc")))# cause pls methods just have 1 ncomp, block approaches have different ncomp per block
+    if (is(object, c("mixo_pls","mixo_spls", "rcc")))# cause pls methods just have 1 ncomp, block approaches have different ncomp per block
     {
         ncomp = object$ncomp
         object$X = list(X = object$X, Y = object$Y) # so that the data is in object$X, either it's a pls or block approach

--- a/R/plotLoadings.R
+++ b/R/plotLoadings.R
@@ -967,10 +967,10 @@ check.input.plotLoadings <- function(object,
     # --
     if (missing(block))
     {
-        if (!is(object, "DA"))
+        if (!inherits(object, "DA"))
         {
             block = object$names$blocks
-        } else  if (is(object, c("mixo_plsda", "mixo_splsda"))) {
+        } else  if (inherits(object, c("mixo_plsda", "mixo_splsda"))) {
             block = "X"
         } else {
             if (!is.null(object$indY))
@@ -982,17 +982,17 @@ check.input.plotLoadings <- function(object,
         }
     }
     
-    if (is(object, c("mixo_plsda", "mixo_splsda")) & (!all(block %in% c(1,"X")) | length(block) > 1 ))
+    if (inherits(object, c("mixo_plsda", "mixo_splsda")) & (!all(block %in% c(1,"X")) | length(block) > 1 ))
         stop("'block' can only be 'X' or '1' for plsda and splsda object")
     
-    if (is(object, c("mixo_plsda", "mixo_splsda","pca")))
+    if (inherits(object, c("mixo_plsda", "mixo_splsda","pca")))
     {
         object$indY = 2
-    } else if (is(object, c("mixo_pls", "mixo_spls"))) {
+    } else if (inherits(object, c("mixo_pls", "mixo_spls"))) {
         object$indY = 3 # we don't want to remove anything in that case, and 3 is higher than the number of blocks which is 2
     }
     
-    if(!is(object, "DA"))
+    if(!inherits(object, "DA"))
         object$indY = length(object$names$blocks)+1  # we don't want to remove anything in that case, and 3 is higher than the number of blocks which is 2
     
     if(is.numeric(block))
@@ -1203,7 +1203,7 @@ get.loadings.ndisplay <- function(object,
     
     #comp
     # ----
-    if (is(object, c("mixo_pls","mixo_spls", "rcc")))# cause pls methods just have 1 ncomp, block approaches have different ncomp per block
+    if (inherits(object, c("mixo_pls","mixo_spls", "rcc")))# cause pls methods just have 1 ncomp, block approaches have different ncomp per block
     {
         ncomp = object$ncomp
         object$X = list(X = object$X, Y = object$Y) # so that the data is in object$X, either it's a pls or block approach

--- a/tests/testthat/test-plotLoadings.R
+++ b/tests/testthat/test-plotLoadings.R
@@ -59,6 +59,24 @@ test_that("plotLoadings.mint.splsda works", code = {
     
 })
 
+
+test_that("plotLoadings.mint.spls works", code = {
+    data(stemcells)
+    samples <- c(1:5,60:64)
+    X <- stemcells$gene[samples, 1:10]
+    Y <- stemcells$gene[samples+5, 1:10]
+    S <- as.character(stemcells$study[samples])
+    
+    res = mint.spls(X = X, Y = Y, ncomp = 3, 
+                    keepX = seq(3, 9, 3), 
+                    keepY = seq(3, 9, 3), 
+                    study = S)
+    pl_res <- plotLoadings(res, contrib = "max")
+    
+    expect_is(pl_res, "list")
+})
+
+
 test_that("plotLoadings margin errrors is handled properly", code = {
     data(nutrimouse)
     Y = nutrimouse$diet


### PR DESCRIPTION
bug: brought the output of `plotLoadings()` on MINT objects in line with the other methods

Within `plotLoadings.mint.pls()`, adjusted the value of `block` in the `plotLoadings.mixo_pls()` call. This means that both the `X` and `Y` loading values are returned, rather than just `X`.