### PR TITLE
Fix for Issue #213

### DIFF
--- a/R/MCV.block.splsda.R
+++ b/R/MCV.block.splsda.R
@@ -115,11 +115,12 @@ MCVfold.block.splsda <-
         # prediction of all samples for each test.keepX and  nrep at comp fixed
         folds.input = folds
         
+        n = nrow(X[[1]])
+        repeated.measure = 1:n
+        
         #-- define the folds --#
         if (validation ==  "Mfold")
         {
-            n = nrow(X[[1]])
-            repeated.measure = 1:n
             
             if (is.null(folds) || !is.numeric(folds) || folds < 2 || folds > n)
             {
@@ -129,7 +130,6 @@ MCVfold.block.splsda <-
             }
         } else if (validation ==  "loo") {
             M = n
-            if(nrepeat != 1) stop("nrepeat should be set to 1 with validation='loo'\n")
         }
         
         all_folds <- lapply(seq_len(nrepeat), function(nrep) {

--- a/R/MCV.block.splsda.R
+++ b/R/MCV.block.splsda.R
@@ -136,6 +136,7 @@ MCVfold.block.splsda <-
             }
         } else if (validation ==  "loo") {
             M = n
+            if(nrepeat != 1) { stop("nrepeat should be set to 1 with validation='loo'\n") }
         }
         
         all_folds <- lapply(seq_len(nrepeat), function(nrep) {

--- a/R/MCV.block.splsda.R
+++ b/R/MCV.block.splsda.R
@@ -122,10 +122,16 @@ MCVfold.block.splsda <-
         if (validation ==  "Mfold")
         {
             
-            if (is.null(folds) || !is.numeric(folds) || folds < 2 || folds > n)
-            {
-                stop("Invalid number of folds.")
-            } else {
+            if (is.null(folds) || !is.numeric(folds)) {
+                stop("'folds' need to be non-NULL and numeric")
+            } 
+            else if (folds < 2) {
+                stop("'folds' needs to be at least 2")  
+            } 
+            else if (folds > n) {
+                stop("'folds' cannot be greater than the number of input samples") 
+            } 
+            else {
                 M = round(folds)
             }
         } else if (validation ==  "loo") {

--- a/R/tune.block.splsda.R
+++ b/R/tune.block.splsda.R
@@ -204,7 +204,7 @@ tune.block.splsda <-
     if (validation == 'loo')
     {
       if (nrepeat != 1)
-        warning("Leave-One-Out validation does not need to be repeated: 'nrepeat' is set to '1'.")
+        message("Leave-One-Out validation does not need to be repeated: 'nrepeat' is set to '1'.")
       nrepeat = 1
     }
     

--- a/tests/testthat/test-tune.block.splsda.R
+++ b/tests/testthat/test-tune.block.splsda.R
@@ -69,3 +69,39 @@ test_that("tune.block.splsda works with and without parallel without auc", {
     # expect_equal(tune11$choice.keepX,tune42$choice.keepX)
     
 })
+
+test_that("(tune.block.splsda:error): catches invalid values of 'folds'", {
+    
+    library(mixOmics)
+    
+    data("breast.TCGA")
+    
+    samples <- c(1:3, 50:52, 79:81)
+    data = list(miRNA = breast.TCGA$data.train$mirna[samples,], 
+                mRNA = breast.TCGA$data.train$mrna[samples,], 
+                proteomics = breast.TCGA$data.train$protein[samples,])
+    Y = breast.TCGA$data.train$subtype[samples]
+
+    design = matrix(0.1, ncol = length(data), nrow = length(data), dimnames = list(names(data), names(data)))
+    diag(design) = 0 # set diagonal to 0s
+
+    # set grid of values for each component to test
+    test.keepX = list (mRNA = c(1,2), 
+                       miRNA = c(1,2), 
+                       proteomics = c(1,2))
+    
+    expect_error(tune.block.splsda(X = data, Y = Y, ncomp = 2, 
+                              test.keepX = test.keepX, design = design, folds=10),
+                 "'folds' cannot be greater than the number of input samples",
+                 fixed=T)
+    
+    expect_error(tune.block.splsda(X = data, Y = Y, ncomp = 2, 
+                              test.keepX = test.keepX, design = design, folds=1),
+                 "'folds' needs to be at least 2",
+                 fixed=T)
+    
+    expect_error(tune.block.splsda(X = data, Y = Y, ncomp = 2, 
+                              test.keepX = test.keepX, design = design, folds="random.value"),
+                 "'folds' need to be non-NULL and numeric",
+                 fixed=T)
+})


### PR DESCRIPTION
As correctly identified by user [@VilenneFrederique](https://github.com/VilenneFrederique), the `tune.block.splsda()` function was behavioring incorrectly when using `validation = "loo"`, such that the `n` parameter (denotes sample size) was *only* being set in the `if(validation == "Mfold")` block. This caused issues down stream as `1:n` is called. If using LOOCV, then `n` was equal to `NA`, raising the error.

Noticed that the warning messages about using a `folds` value not equal to 1 in LOOCV situations wasn't printing. Adjusted it so users were notified of this as well as expanded some of the `stop()` calls to more specifically notify users of what the issue was with their inputted value of `folds`.