### PR TITLE
Fix for Issue #148

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,5 +63,5 @@ biocViews: ImmunoOncology,
            MultipleComparison, 
            Classification, 
            Regression
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Encoding: UTF-8

--- a/R/block.spls.R
+++ b/R/block.spls.R
@@ -50,6 +50,9 @@
 #' default all variables are kept in the model.
 #' @param keepY Only if Y is provided (and not \code{indY}). Each entry is the number of variables to
 #' select in each of the blocks of Y for each component.
+#' @param retain.feats character/numeric list indicating what specific variables
+#' should be retained and used in the model. This works independently of 
+#' \code{keepX/Y}. By default, none are retained.
 #' @return \code{block.spls} returns an object of class \code{"block.spls"}, a
 #' list that contains the following components:
 #' 
@@ -101,7 +104,8 @@ block.spls = function(X,
                       tol = 1e-06,
                       max.iter = 100,
                       near.zero.var = FALSE,
-                      all.outputs = TRUE)
+                      all.outputs = TRUE,
+                      retain.feats = NULL)
 {
     
     # call to 'internal_wrapper.mint.block'
@@ -120,7 +124,8 @@ block.spls = function(X,
         tol = tol,
         max.iter = max.iter,
         near.zero.var = near.zero.var,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        retain.feats = retain.feats
     )
     
     # calculate weights for each dataset

--- a/R/block.splsda.R
+++ b/R/block.splsda.R
@@ -97,7 +97,8 @@ block.splsda <- function(X,
                          tol = 1e-06,
                          max.iter = 100,
                          near.zero.var = FALSE,
-                         all.outputs = TRUE)
+                         all.outputs = TRUE,
+                         retain.feats = NULL)
 {
     # check inpuy 'Y' and transformation in a dummy matrix
     if (!missing(Y))
@@ -156,7 +157,8 @@ block.splsda <- function(X,
         tol = tol,
         max.iter = max.iter,
         near.zero.var = near.zero.var,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        retain.feats = retain.feats
     )
     
     # calculate weights for each dataset

--- a/R/check_entry.R
+++ b/R/check_entry.R
@@ -179,7 +179,7 @@ Check.entry.single = function(X,  ncomp, q)
 
 
 Check.entry.pls = function(X, Y, ncomp, keepX, keepY, test.keepX, test.keepY,
-                           mode, scale, near.zero.var, max.iter, tol, logratio, DA, multilevel, retain.feats)
+                           mode, scale, near.zero.var, max.iter, tol, logratio, DA, multilevel, retain.feats=NULL)
 {
     
     if (missing(mode))
@@ -266,7 +266,7 @@ Check.entry.pls = function(X, Y, ncomp, keepX, keepY, test.keepX, test.keepY,
         
         b <- list(X=X, Y=Y)
         if (DA) {b <- list(X=X)}
-        Check.retain.feats(retain.feats, b)
+        retain.feats <- Check.retain.feats(retain.feats, b)
     }
     
     
@@ -439,7 +439,7 @@ Check.entry.wrapper.mint.block = function(X,
                                           mode,
                                           tol,
                                           max.iter,
-                                          retain.feats)
+                                          retain.feats=NULL)
 {
     #need to give the default values of mint.block.spls to mixOmics
     
@@ -508,7 +508,7 @@ Check.entry.wrapper.mint.block = function(X,
     
     if(!is.null(retain.feats)) {
         
-        Check.retain.feats(retain.feats, X)
+       retain.feats <- Check.retain.feats(retain.feats, X)
     }
     
     
@@ -1105,5 +1105,7 @@ Check.retain.feats <- function(retain.feats, blocks) {
             }
         }
     }
+    
+    return(retain.feats)
 }
 

--- a/R/internal_mint.block.R
+++ b/R/internal_mint.block.R
@@ -693,6 +693,7 @@ sparse.mint.block_iteration = function (A, design, study = NULL, loadings.A,
         ### Start: Match algorithm with mixOmics algo (stopping point)
         diff.value <- max(sapply(1:J, function(x){crossprod(loadings.A[[x]] -
                                                                 loadings.A_old[[x]])}))
+        
         if (diff.value < tol | iter > max.iter)
             break
         ### End: Match algorithm with mixOmics algo (stopping point)

--- a/R/internal_mint.block_helpers.R
+++ b/R/internal_mint.block_helpers.R
@@ -121,7 +121,7 @@ study_split <- function(data, study)
 #' 
 #' soft_thresholding_L1(x = x2, nx = 2)
 #' #> 0.01 -0.31  0.00  0.00
-soft_thresholding_L1 <- function(x, nx, retain.feats)
+soft_thresholding_L1 <- function(x, nx, retain.feats=NULL)
 {
     if (nx > 0)
     { 
@@ -132,7 +132,7 @@ soft_thresholding_L1 <- function(x, nx, retain.feats)
         if (!all(select_feature))
         {
             x <- ifelse(test = (select_feature | retain_feature),  #  
-                        yes = sign(x) * (abs.a), # - max(abs.a[!select_feature])
+                        yes = sign(x) * (abs.a- max(abs.a[!(select_feature | retain_feature)])), # - max(abs.a[!(select_feature | retain_feature)])
                         no = 0)
         }
     }

--- a/R/internal_mint.block_helpers.R
+++ b/R/internal_mint.block_helpers.R
@@ -132,7 +132,7 @@ soft_thresholding_L1 <- function(x, nx, retain.feats=NULL)
         if (!all(select_feature))
         {
             x <- ifelse(test = (select_feature | retain_feature),  #  
-                        yes = sign(x) * (abs.a- max(abs.a[!(select_feature | retain_feature)])), # - max(abs.a[!(select_feature | retain_feature)])
+                        yes = sign(x) * (abs.a - max(abs.a[!(select_feature | retain_feature)])), # - max(abs.a[!(select_feature | retain_feature)])
                         no = 0)
         }
     }

--- a/R/internal_mint.block_helpers.R
+++ b/R/internal_mint.block_helpers.R
@@ -121,16 +121,18 @@ study_split <- function(data, study)
 #' 
 #' soft_thresholding_L1(x = x2, nx = 2)
 #' #> 0.01 -0.31  0.00  0.00
-soft_thresholding_L1 <- function(x, nx)
+soft_thresholding_L1 <- function(x, nx, retain.feats)
 {
     if (nx > 0)
-    {
+    { 
         abs.a = abs(x)
         select_feature <- rank(abs.a, ties.method = "max") > nx
+        if (!is.null(retain.feats)) { retain_feature <- 1:length(abs.a) %in% retain.feats } #  select_feature[1:length(abs.a) %in% retain.feats] <- T
+        else {retain_feature <- rep(F, length(abs.a));}
         if (!all(select_feature))
         {
-            x <- ifelse(test = select_feature, 
-                        yes = sign(x) * (abs.a - max(abs.a[!select_feature])), 
+            x <- ifelse(test = (select_feature | retain_feature),  #  
+                        yes = sign(x) * (abs.a), # - max(abs.a[!select_feature])
                         no = 0)
         }
     }
@@ -186,12 +188,11 @@ norm2 <- function(vec)
 # --------------------------------------
 # sparsity function: used in 'internal_mint.block.R'
 # --------------------------------------
-sparsity <- function(loadings.A, keepA, penalty=NULL)
+sparsity <- function(loadings.A, keepA, penalty=NULL, retain.feats=NULL)
 {
-    
     if (!is.null(keepA)) {
         nx = length(loadings.A) - keepA
-        loadings.A = soft_thresholding_L1(loadings.A, nx = nx)
+        loadings.A = soft_thresholding_L1(loadings.A, nx = nx, retain.feats)
     } else if (!is.null(penalty)) {
         loadings.A = soft.threshold(loadings.A, penalty)
     }

--- a/R/internal_wrapper.mint.R
+++ b/R/internal_wrapper.mint.R
@@ -51,6 +51,8 @@
 #   with withinVariation
 # multilevel: multilevel is passed to multilevel(design=) in withinVariation.
 #   Y is omitted and should be included in multilevel design
+# retain.feats: the list of features on each block which are to keep kept as 
+#   part of the model
 
 internal_wrapper.mint <- 
   function(X,
@@ -71,7 +73,8 @@ internal_wrapper.mint <-
            multilevel = NULL,
            misdata = NULL, is.na.A = NULL, ind.NA = NULL, ind.NA.col = NULL,
            all.outputs=FALSE,
-           remove.object=NULL
+           remove.object=NULL,
+           retain.feats = NULL
   )
   {
     
@@ -82,7 +85,7 @@ internal_wrapper.mint <-
     
     check = Check.entry.pls(X, Y, ncomp, keepX, keepY, mode=mode, scale=scale,
                             near.zero.var=near.zero.var, max.iter=max.iter ,tol=tol ,logratio=logratio,
-                            DA=DA, multilevel=multilevel)
+                            DA=DA, multilevel=multilevel, retain.feats=retain.feats)
     X = check$X
     input.X = X # save the checked X, before logratio/multileve/scale
     Y = check$Y
@@ -92,6 +95,7 @@ internal_wrapper.mint <-
     keepY = check$keepY
     nzv.A = check$nzv.A
     multilevel <- check$multilevel
+    retain.feats = check$retain.feats
     rm(check) # free memory
     #remove `X' from the previous environment
     if(!is.null(remove.object))
@@ -198,14 +202,14 @@ internal_wrapper.mint <-
     #-- keepA ----------------------------------------------------#
     #--------------------------------------------------------------------------#
     
-    
     #--------------------------------------------------------------------------#
     #-- pls approach ----------------------------------------------------#
     result = internal_mint.block(A = list(X = X, Y = Y), indY = 2, mode = mode,
                                  ncomp = c(ncomp, ncomp), tol = tol, max.iter = max.iter,
                                  design = design, keepA = keepA, scale = scale, scheme = "horst",init="svd",
                                  study = study, misdata = misdata, is.na.A = is.na.A, ind.NA = ind.NA,
-                                 ind.NA.col = ind.NA.col, all.outputs= all.outputs, remove.object=c("X"))
+                                 ind.NA.col = ind.NA.col, all.outputs= all.outputs, remove.object=c("X"),
+                                 retain.feats = retain.feats)
     
     #-- pls approach ----------------------------------------------------#
     #--------------------------------------------------------------------------#

--- a/R/internal_wrapper.mint.block.R
+++ b/R/internal_wrapper.mint.block.R
@@ -58,7 +58,8 @@ internal_wrapper.mint.block <-
              max.iter = 100,
              near.zero.var = FALSE,
              misdata = NULL, is.na.A = NULL, ind.NA = NULL, ind.NA.col = NULL,
-             all.outputs=TRUE
+             all.outputs=TRUE,
+             retain.feats = NULL
     )
     {
         if (missing(scheme))
@@ -73,7 +74,7 @@ internal_wrapper.mint.block <-
                                              ncomp = ncomp, keepX = keepX, keepY = keepY, DA=DA,
                                              study = study, design = design, init = init, scheme = scheme, scale = scale,
                                              near.zero.var = near.zero.var, mode = mode, tol = tol,
-                                             max.iter = max.iter)
+                                             max.iter = max.iter, retain.feats = retain.feats)
         
         # get some values after checks
         A = check$A
@@ -85,6 +86,7 @@ internal_wrapper.mint.block <-
         keepA.save = keepA
         init = check$init
         nzv.A = check$nzv.A
+        retain.feats = check$retain.feats
         
         #--------------------------------------------------------------------------#
         #-- keepA ----------------------------------------------------#
@@ -145,7 +147,8 @@ internal_wrapper.mint.block <-
                                    study = study,
                                    keepA = keepA,
                                    misdata = misdata, is.na.A = is.na.A, ind.NA = ind.NA,
-                                   ind.NA.col = ind.NA.col, all.outputs= all.outputs)
+                                   ind.NA.col = ind.NA.col, all.outputs= all.outputs,
+                                   retain.feats = retain.feats)
         
         if(near.zero.var)
             result$nzv=nzv.A

--- a/R/mint.spls.R
+++ b/R/mint.spls.R
@@ -45,6 +45,9 @@
 #' \code{X} on each component. By default all variables are kept in the model.
 #' @param keepY numeric vector indicating the number of variables to select in
 #' \code{Y} on each component. By default all variables are kept in the model.
+#' @param retain.feats character/numeric list indicating what specific variables
+#' should be retained and used in the model. This works independently of 
+#' \code{keepX/Y}. By default, none are retained.
 #' @return \code{mint.spls} returns an object of class
 #' \code{"mint.spls","spls"}, a list that contains the following components:
 #' 
@@ -115,7 +118,8 @@ mint.spls <- function(X,
                       tol = 1e-06,
                       max.iter = 100,
                       near.zero.var = FALSE,
-                      all.outputs = TRUE)
+                      all.outputs = TRUE,
+                      retain.feats = NULL)
 {
     
     # call to 'internal_wrapper.mint'
@@ -131,7 +135,8 @@ mint.spls <- function(X,
         keepY = keepY,
         max.iter = max.iter,
         tol = tol,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        retain.feats = retain.feats
     )
     
     # choose the desired output from 'result'

--- a/R/mint.splsda.R
+++ b/R/mint.splsda.R
@@ -106,7 +106,8 @@ mint.splsda <- function(X,
                         tol = 1e-06,
                         max.iter = 100,
                         near.zero.var = FALSE,
-                        all.outputs = TRUE)
+                        all.outputs = TRUE,
+                        retain.feats = NULL)
 {
     
     #-- validation des arguments --#
@@ -150,7 +151,9 @@ mint.splsda <- function(X,
         max.iter = max.iter,
         tol = tol,
         scale = scale,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        retain.feats = retain.feats,
+        DA = TRUE
     )
     
     # choose the desired output from 'result'

--- a/R/spls.R
+++ b/R/spls.R
@@ -19,6 +19,9 @@
 #' @param keepX numeric vector of length \code{ncomp}, the number of variables
 #' to keep in \eqn{X}-loadings. By default all variables are kept in the model.
 #' @param keepY numeric vector of length \code{ncomp}, the number of variables
+#' @param retain.feats character/numeric list indicating what specific variables
+#' should be retained and used in the model. This works independently of 
+#' \code{keepX/Y}. By default, none are retained.
 #' @return \code{spls} returns an object of class \code{"spls"}, a list that
 #' contains the following components:
 #' \item{X}{the centered and standardized original predictor matrix.}
@@ -101,7 +104,8 @@ spls <- function(X,
                  logratio = "none",
                  # one of "none", "CLR"
                  multilevel = NULL,
-                 all.outputs = TRUE)
+                 all.outputs = TRUE,
+                 retain.feats = NULL)
 {
     
     
@@ -120,7 +124,8 @@ spls <- function(X,
         logratio = logratio,
         multilevel = multilevel,
         DA = FALSE,
-        all.outputs = all.outputs
+        all.outputs = all.outputs,
+        retain.feats = retain.feats
     )
     
     # choose the desired output from 'result'

--- a/R/splsda.R
+++ b/R/splsda.R
@@ -81,7 +81,8 @@ splsda <- function(X,
                    logratio = "none",
                    # one of "none", "CLR"
                    multilevel = NULL,
-                   all.outputs = TRUE)
+                   all.outputs = TRUE,
+                   retain.feats = NULL)
 {
     
     
@@ -139,7 +140,8 @@ splsda <- function(X,
         multilevel = multilevel,
         DA = TRUE,
         all.outputs = all.outputs,
-        remove.object = c("X")
+        remove.object = c("X"),
+        retain.feats = retain.feats
     )
     
     

--- a/man/block.spls.Rd
+++ b/man/block.spls.Rd
@@ -20,7 +20,8 @@ block.spls(
   tol = 1e-06,
   max.iter = 100,
   near.zero.var = FALSE,
-  all.outputs = TRUE
+  all.outputs = TRUE,
+  retain.feats = NULL
 )
 }
 \arguments{
@@ -80,6 +81,10 @@ computations. Default value is FALSE.}
 
 \item{all.outputs}{Logical. Computation can be faster when some specific
 (and non-essential) outputs are not calculated. Default = \code{TRUE}.}
+
+\item{retain.feats}{character/numeric list indicating what specific variables
+should be retained and used in the model. This works independently of 
+\code{keepX/Y}. By default, none are retained.}
 }
 \value{
 \code{block.spls} returns an object of class \code{"block.spls"}, a

--- a/man/block.splsda.Rd
+++ b/man/block.splsda.Rd
@@ -19,7 +19,8 @@ block.splsda(
   tol = 1e-06,
   max.iter = 100,
   near.zero.var = FALSE,
-  all.outputs = TRUE
+  all.outputs = TRUE,
+  retain.feats = NULL
 )
 
 wrapper.sgccda(
@@ -35,7 +36,8 @@ wrapper.sgccda(
   tol = 1e-06,
   max.iter = 100,
   near.zero.var = FALSE,
-  all.outputs = TRUE
+  all.outputs = TRUE,
+  retain.feats = NULL
 )
 }
 \arguments{
@@ -87,6 +89,10 @@ computations. Default value is FALSE.}
 
 \item{all.outputs}{Logical. Computation can be faster when some specific
 (and non-essential) outputs are not calculated. Default = \code{TRUE}.}
+
+\item{retain.feats}{character/numeric list indicating what specific variables
+should be retained and used in the model. This works independently of 
+\code{keepX/Y}. By default, none are retained.}
 }
 \value{
 \code{block.splsda} returns an object of class \code{"block.splsda",

--- a/man/mint.spls.Rd
+++ b/man/mint.spls.Rd
@@ -16,7 +16,8 @@ mint.spls(
   tol = 1e-06,
   max.iter = 100,
   near.zero.var = FALSE,
-  all.outputs = TRUE
+  all.outputs = TRUE,
+  retain.feats = NULL
 )
 }
 \arguments{
@@ -57,6 +58,10 @@ computations. Default value is FALSE.}
 
 \item{all.outputs}{Logical. Computation can be faster when some specific
 (and non-essential) outputs are not calculated. Default = \code{TRUE}.}
+
+\item{retain.feats}{character/numeric list indicating what specific variables
+should be retained and used in the model. This works independently of 
+\code{keepX/Y}. By default, none are retained.}
 }
 \value{
 \code{mint.spls} returns an object of class

--- a/man/mint.splsda.Rd
+++ b/man/mint.splsda.Rd
@@ -14,7 +14,8 @@ mint.splsda(
   tol = 1e-06,
   max.iter = 100,
   near.zero.var = FALSE,
-  all.outputs = TRUE
+  all.outputs = TRUE,
+  retain.feats = NULL
 )
 }
 \arguments{
@@ -48,6 +49,10 @@ computations. Default value is FALSE.}
 
 \item{all.outputs}{Logical. Computation can be faster when some specific
 (and non-essential) outputs are not calculated. Default = \code{TRUE}.}
+
+\item{retain.feats}{character/numeric list indicating what specific variables
+should be retained and used in the model. This works independently of 
+\code{keepX/Y}. By default, none are retained.}
 }
 \value{
 \code{mint.splsda} returns an object of class \code{"mint.splsda",

--- a/man/spca.Rd
+++ b/man/spca.Rd
@@ -13,7 +13,8 @@ spca(
   max.iter = 500,
   tol = 1e-06,
   logratio = c("none", "CLR"),
-  multilevel = NULL
+  multilevel = NULL,
+  retain.feats = NULL
 )
 }
 \arguments{
@@ -51,6 +52,10 @@ specific normalisation in sequencing data. Default to 'none'}
 
 \item{multilevel}{sample information for multilevel decomposition for
 repeated measurements.}
+
+\item{retain.feats}{character/numeric list indicating what specific variables
+should be retained and used in the model. This works independently of 
+\code{keepX/Y}. By default, none are retained.}
 }
 \value{
 \code{spca} returns a list with class \code{"spca"} containing the

--- a/man/spls.Rd
+++ b/man/spls.Rd
@@ -17,7 +17,8 @@ spls(
   near.zero.var = FALSE,
   logratio = "none",
   multilevel = NULL,
-  all.outputs = TRUE
+  all.outputs = TRUE,
+  retain.feats = NULL
 )
 }
 \arguments{
@@ -64,6 +65,10 @@ columns indicate those factors. See examples.}
 
 \item{all.outputs}{Logical. Computation can be faster when some specific
 (and non-essential) outputs are not calculated. Default = \code{TRUE}.}
+
+\item{retain.feats}{character/numeric list indicating what specific variables
+should be retained and used in the model. This works independently of 
+\code{keepX/Y}. By default, none are retained.}
 }
 \value{
 \code{spls} returns an object of class \code{"spls"}, a list that

--- a/man/splsda.Rd
+++ b/man/splsda.Rd
@@ -15,7 +15,8 @@ splsda(
   near.zero.var = FALSE,
   logratio = "none",
   multilevel = NULL,
-  all.outputs = TRUE
+  all.outputs = TRUE,
+  retain.feats = NULL
 )
 }
 \arguments{
@@ -55,6 +56,10 @@ in \code{?splsda}.}
 
 \item{all.outputs}{Logical. Computation can be faster when some specific
 (and non-essential) outputs are not calculated. Default = \code{TRUE}.}
+
+\item{retain.feats}{character/numeric list indicating what specific variables
+should be retained and used in the model. This works independently of 
+\code{keepX/Y}. By default, none are retained.}
 }
 \value{
 \code{splsda} returns an object of class \code{"splsda"}, a list


### PR DESCRIPTION
Users requested some time ago to include a feature within our sparse methods which allows for them to pass in a specific set of variables to be guaranteed to be included in the model. Relevant user facing functions (`spca`, `(mint).(block).spls(da)`) all now take the `retain.feats` parameter to allow this funcitonality.

`Check.retain.feats()` handles checks and pre-processing of the input `retain.feats`. This parameter influences the regularisation that occurs within `soft_threshold_L1()` called by `sparsity()`. Along with `select_feature`, all features included as part of `retain.feats` do NOT have their loadings reduced to 0. 

