### PR TITLE
PR addressing Issue #24

### DIFF
--- a/R/internal_graphicModule.R
+++ b/R/internal_graphicModule.R
@@ -478,6 +478,31 @@ internal_graphicModule <-
                                       inherit.aes = FALSE)
                 }
             }
+
+            if(!is.null(background))
+            {
+                for(i in 1:length(background))
+                {
+                    if(!is.null(background[[i]]))
+                        background[[i]]=data.frame(id=i,col=names(background)[i],
+                                                   background[[i]])
+                }
+                
+                background = do.call(rbind,background)
+                
+                p = p+geom_polygon(data = background,aes(x=Var1, y=Var2,
+                                                         fill = col), inherit.aes = FALSE, show.legend
+                                   =FALSE)
+                col.vals <- as.character(unique(background$col))
+                names(col.vals) <- col.vals
+                p = p + scale_fill_manual(values =
+                                              col.vals)
+                
+                if(is.null(xlim))
+                    xlim = range(df$x)
+                if(is.null(ylim))
+                    ylim = range(df$y)
+            }
             
             plot(p)
         }

--- a/R/internal_mint.block_helpers.R
+++ b/R/internal_mint.block_helpers.R
@@ -311,14 +311,14 @@ mean_centering_per_study <- function(data, study, scale)
                 attr(concat.data,paste0("sigma:", levels(study)[m])) = NULL
             }
         }
+    }
+
+    attr(concat.data,"scaled:center") = meanX[[1]]
+    if (scale)
+    {
+        attr(concat.data,"scaled:scale") = sqrt.sdX[[1]]
     } else {
-        attr(concat.data,"scaled:center") = meanX[[1]]
-        if (scale)
-        {
-            attr(concat.data,"scaled:scale") = sqrt.sdX[[1]]
-        } else {
-            attr(concat.data,"scaled:scale") = NULL
-        }
+        attr(concat.data,"scaled:scale") = NULL
     }
     
     return(list(concat.data=concat.data, rownames.study=rownames.study))

--- a/R/plotIndiv.mint.R
+++ b/R/plotIndiv.mint.R
@@ -373,10 +373,12 @@ plotIndiv.mint.pls <-
             # we choose xlim/ylim that fits the points and the background by finding the
             # average between the extremes of the two. 
             # 0.5 then added to min of the lim to prevent any uncoloured area showing
+            bg.tmp <- (do.call("rbind", background))
             if(is.null(xlim))
-                xlim <- (range(df$x) + range(background[, "Var1"]))/2 + c(0.5, 0)
+                xlim <- (range(df$x) + range(bg.tmp[, "Var1"]))/2 + c(0.5, 0)
             if(is.null(ylim))
-                ylim <- (range(df$y) + range(background[, "Var2"]))/2 + c(0.5, 0)
+                ylim <- (range(df$y) + range(bg.tmp[, "Var2"]))/2 + c(0.5, 0)
+            rm(bg.tmp)
         }
         
 

--- a/R/plotIndiv.mint.R
+++ b/R/plotIndiv.mint.R
@@ -40,6 +40,7 @@ plotIndiv.mint.pls <-
              legend.title = "Legend",
              legend.position = "right",
              point.lwd = 1,
+             background = NULL,
              ...
              
     )
@@ -361,8 +362,25 @@ plotIndiv.mint.pls <-
         }
         df = df.final
         
-        if (style == "ggplot2")
+        if (style == "ggplot2") {
             style = "ggplot2-MINT"
+        }
+
+        if(!is.null(background)) {
+            ind.match = match(names(background), levels(df$group))
+            names(background) = adjustcolor(col.per.group[ind.match],alpha.f=0.1)
+
+            # we choose xlim/ylim that fits the points and the background by finding the
+            # average between the extremes of the two. 
+            # 0.5 then added to min of the lim to prevent any uncoloured area showing
+            if(is.null(xlim))
+                xlim <- (range(df$x) + range(background[, "Var1"]))/2 + c(0.5, 0)
+            if(is.null(ylim))
+                ylim <- (range(df$y) + range(background[, "Var2"]))/2 + c(0.5, 0)
+        }
+        
+
+        
         
         #call plot module (ggplot2, lattice, graphics, 3d)
         res = internal_graphicModule(
@@ -383,6 +401,7 @@ plotIndiv.mint.pls <-
             df.ellipse = df.ellipse,
             style = style,
             layout = layout,
+            background = background,
             #missing.col = missing.col,
             #for ggplot2-MINT
             study.levels = study.levels,

--- a/man/plotIndiv.Rd
+++ b/man/plotIndiv.Rd
@@ -49,6 +49,7 @@ plotIndiv(object, ...)
   legend.title = "Legend",
   legend.position = "right",
   point.lwd = 1,
+  background = NULL,
   ...
 )
 
@@ -86,6 +87,7 @@ plotIndiv(object, ...)
   legend.title = "Legend",
   legend.position = "right",
   point.lwd = 1,
+  background = NULL,
   ...
 )
 
@@ -123,6 +125,7 @@ plotIndiv(object, ...)
   legend.title = "Legend",
   legend.position = "right",
   point.lwd = 1,
+  background = NULL,
   ...
 )
 
@@ -160,6 +163,7 @@ plotIndiv(object, ...)
   legend.title = "Legend",
   legend.position = "right",
   point.lwd = 1,
+  background = NULL,
   ...
 )
 
@@ -438,6 +442,9 @@ is not "global"}
 \item{point.lwd}{\code{lwd} of the points, used when \code{ind.names =
 FALSE}}
 
+\item{background}{color the background by the predicted class, see
+\code{\link{background.predict}}}
+
 \item{ind.names}{either a character vector of names for the individuals to
 be plotted, or \code{FALSE} for no names. If \code{TRUE}, the row names of
 the first (or second) data matrix is used as names (see Details).}
@@ -455,9 +462,6 @@ for the legend.}
 
 \item{legend.title.pch}{title of the second legend created by \code{pch}, if
 any.}
-
-\item{background}{color the background by the predicted class, see
-\code{\link{background.predict}}}
 
 \item{blocks}{integer value or name(s) of block(s) to be plotted using the
 GCCA module. "average" and "weighted.average" will create average and

--- a/tests/testthat/test-plotIndiv.R
+++ b/tests/testthat/test-plotIndiv.R
@@ -167,19 +167,23 @@ test_that("plotIndiv.sgccda(..., blocks = 'average') works with ellipse=TRUE", c
     expect_true(all(unique(diablo_plot$df.ellipse$Block) %in% c('average', 'Block: mrna', 'average (weighted)')))
 })
 
-test_that("plotIndiv.mint.plsda() works with ellipse=TRUE", code = {
-  
+
+test_that("mint.splsda can be visualised with predicted background", {
   data(stemcells)
   X <- stemcells$gene
   Y <- stemcells$celltype
   S <- stemcells$study
-  
-  model <- mint.plsda(X, Y, study = S)
-  
-  pl.res <- plotIndiv(model, ellipse = T)
-  
-  .expect_numerically_close(pl.res$graph$data$x[10], -3.129)
-  .expect_numerically_close(pl.res$graph$data$y[20], -5.3516)
+
+  model <- mint.splsda(X = X,
+                       Y = Y,
+                       study = S)
+
+  bgp <- background.predict(model, comp.predicted = 2,
+                            resolution = 10)
+
+  output <- plotIndiv(model, background = bgp, style = "ggplot2")
+
+  expect_equal(dim(output$df), c(125, 9))
 })
 
 unlink(list.files(pattern = "*.pdf"))


### PR DESCRIPTION
Derives from closed and depreciated PR (#198).

Mostly the same implementation, such that:

- `plotIndiv.mint.pls()` given functionality to process `background.predict` objects. Included adjusting way in which X and Y axes limits are calculated to ensure polygons show
- `mean_centering_per_study()` adjusted to add the global `scaled:center` and `scaled:scale` attributes to output. 
- `internal_graphicModule()` had the `if (style == "ggplot2-MINT")` updated to include background polygons in `plotIndiv()` figures.
- documentation and SemVer updated.
 
Commits and commit messages were redone too. 