### PR TITLE
PR addressing Issue #122

### DIFF
--- a/R/perf.R
+++ b/R/perf.R
@@ -808,6 +808,12 @@ perf.mixo_plsda <- function(object,
             warning("Leave-One-Out validation does not need to be repeated: 'nrepeat' is set to '1'.")
         nrepeat = 1
     }
+
+    if (any(table(object$Y) <= 1)) {
+        stop(paste("Cannot evaluate performance when a class level ('", 
+                   names(table(object$Y))[which(table(object$Y) == 1)],
+                   "') has only a single assocaited sample.", sep = ""))
+    }
     
     if (nrepeat < 3 && validation != "loo") {
         warning("Values in '$choice.ncomp' will reflect component count with the minimum error rate rather than the best based on a one-way t.test")

--- a/tests/testthat/test-perf.mixo.splsda.R
+++ b/tests/testthat/test-perf.mixo.splsda.R
@@ -1,0 +1,28 @@
+test_that("perf.mixo_splsda functions", code = {
+    data(liver.toxicity)
+    X <- liver.toxicity$gene
+    Y <- liver.toxicity$treatment$Dose.Group
+
+    set.seed(12)
+    res <- plsda(X, Y, ncomp = 2)
+    out <- perf(res, validation = "Mfold", folds = 3, nrepeat = 3)
+
+    ground.ncomp <- matrix(c(2,1,2,2,1,2), ncol = 3, byrow=T,
+                           dimnames = list(c("overall", "BER"),
+                                           c("max.dist", "centroids.dist", "mahalanobis.dist")))
+
+    expect_equal(out$choice.ncomp, ground.ncomp)
+})
+
+test_that("does not allow for class with 1 associated sample", code = {
+    data(liver.toxicity)
+    X <- liver.toxicity$gene
+    Y <- liver.toxicity$treatment$Dose.Group
+    # create a class with one sample only
+    Y[c(1)] <- 'random.class'
+
+    res <- plsda(X, Y, ncomp = 2)
+
+    expect_error(perf(res, validation = "Mfold", folds = 3, nrepeat = 3),
+                 "single assocaited")
+})


### PR DESCRIPTION
Derives from closed and depreciated PR (https://github.com/mixOmicsTeam/mixOmics/pull/195).

Mostly the same implementation, such that:

- Small check added to `perf.mixo_splsda()` to notify user if any class contains only one sample
- tests in new `test-perf.mixo.splsda.R` to maintain coverage

Commits and commit messages were redone too.