### PR TITLE
PR addressing Issue #233

### DIFF
--- a/R/network.R
+++ b/R/network.R
@@ -652,8 +652,8 @@ network <- function(mat,
     
     #-- size.node
     if (!is.null(size.node)) {
-      if (!is.finite(size.node) || size.node < 0 || length(size.node)>1) {
-        stop("'size.node' must be a non-negative numerical value.", call. = FALSE)
+      if (!is.finite(size.node) || size.node < 0 || size.node > 1 || length(size.node)>1) {
+        stop("'size.node' must be a numerical value between 0 - 1.", call. = FALSE)
       }
       if (size.node == 0) {
         shape.node <- "none"
@@ -1010,7 +1010,7 @@ network <- function(mat,
     plot(1:100, 1:100, type = "n", axes = FALSE, xlab = "", ylab = "")
     cha = V(gR)$label
     cha = paste("", cha, "")
-    xh = strwidth(cha, cex = ifelse(is.null(size.node), cex0, size.node*2)) * 1.5
+    xh = strwidth(cha, cex = ifelse(is.null(size.node), cex0, size.node*4)) * 1.5
     yh = strheight(cha, cex = cex0) * 3
     
     V(gR)$size = xh

--- a/R/network.R
+++ b/R/network.R
@@ -935,6 +935,9 @@ network <- function(mat,
         {
             V(gR)$color[V(gR)$group == i] = color.node[j]
             V(gR)$shape[V(gR)$group == i] = shape.node[j]
+            if (shape.node[j] == "none") {
+              V(gR)$label.color[V(gR)$group == i] = paste0(substr(color.node[j], 1, 7), "FF")
+            }
             j = j + 1
         }
     } else {
@@ -943,7 +946,14 @@ network <- function(mat,
         V(gR)$color[V(gR)$group == "y"] = color.node[2]
         
         V(gR)$shape = shape.node[1]
+        if (shape.node[1] == "none") {
+          V(gR)$label.color = paste0(substr(color.node[1], 1, 7), "FF")
+        }
         V(gR)$shape[V(gR)$group == "y"] = shape.node[2]
+        if (shape.node[2] == "none") {
+          V(gR)$label.color[V(gR)$group == "y"] = paste0(substr(color.node[1], 1, 7), "FF")
+        }
+        
     }
     
     # edges attributes #

--- a/R/network.R
+++ b/R/network.R
@@ -181,7 +181,7 @@ network <- function(mat,
                     row.names = TRUE,
                     col.names = TRUE,
                     block.var.names = TRUE,
-                    size.node = NULL,
+                    size.node = 0.5,
                     color.node = NULL,
                     shape.node = NULL,
                     alpha.node = 0.85,
@@ -1010,7 +1010,7 @@ network <- function(mat,
     plot(1:100, 1:100, type = "n", axes = FALSE, xlab = "", ylab = "")
     cha = V(gR)$label
     cha = paste("", cha, "")
-    xh = strwidth(cha, cex = ifelse(is.null(size.node), cex0, size.node*4)) * 1.5
+    xh = strwidth(cha, cex = ifelse(size.node==0.5, cex0, size.node*4)) * 1.5
     yh = strheight(cha, cex = cex0) * 3
     
     V(gR)$size = xh

--- a/R/network.R
+++ b/R/network.R
@@ -181,6 +181,7 @@ network <- function(mat,
                     row.names = TRUE,
                     col.names = TRUE,
                     block.var.names = TRUE,
+                    graph.scale = 0.5,
                     size.node = 0.5,
                     color.node = NULL,
                     shape.node = NULL,
@@ -661,6 +662,11 @@ network <- function(mat,
       }
     }
     
+    #-- graph.scale
+    if (!is.finite(graph.scale) || graph.scale < 0 || graph.scale > 1 || length(graph.scale)>1) {
+      stop("'graph.scale' must be a numerical value between 0 - 1.", call. = FALSE)
+    }
+    
     #-- color.node
     if(any(class.object %in% object.blocks))
     {
@@ -1007,7 +1013,8 @@ network <- function(mat,
     def.par = par(no.readonly = TRUE)
     dev.new()
     par(pty = "s", mar = c(0, 0, 0, 0),mfrow=c(1,1))
-    plot(1:100, 1:100, type = "n", axes = FALSE, xlab = "", ylab = "")
+    upr.bnd <- 190*(graph.scale^2) + 10
+    plot(1:upr.bnd, 1:upr.bnd, type = "n", axes = FALSE, xlab = "", ylab = "")
     cha = V(gR)$label
     cha = paste("", cha, "")
     xh = strwidth(cha, cex = ifelse(size.node==0.5, cex0, size.node*4)) * 1.5

--- a/R/network.R
+++ b/R/network.R
@@ -686,7 +686,8 @@ network <- function(mat,
         }
     } else {
         if(is.null(color.node))
-            color.node=c("white", "white")
+            color.node = brewer.pal(n = 12, name = 'Paired')[c(1,3)]
+            color.node = adjustcolor(color.node, alpha.f = alpha.node)
         
         if (!is.list(color.node))
         {
@@ -951,7 +952,7 @@ network <- function(mat,
         }
         V(gR)$shape[V(gR)$group == "y"] = shape.node[2]
         if (shape.node[2] == "none") {
-          V(gR)$label.color[V(gR)$group == "y"] = paste0(substr(color.node[1], 1, 7), "FF")
+          V(gR)$label.color[V(gR)$group == "y"] = paste0(substr(color.node[2], 1, 7), "FF")
         }
         
     }

--- a/R/network.R
+++ b/R/network.R
@@ -96,6 +96,11 @@
 #' threshold for the relevant associations network (see Details).
 #' @param row.names,col.names character vector containing the names of \eqn{X}-
 #' and \eqn{Y}-variables.
+#' @param graph.scale Numeric between 0 and 1 which alters the scale of the entire
+#' plot. Increasing the value decreases the size of nodes and increases their distance
+#' from one another. Defaults to 0.5.
+#' @param size.node Numeric between 0 and 1 which determines the relative size of nodes.
+#' Defaults to 0.5.
 #' @param color.node vector of length two, the colors of the \eqn{X} and
 #' \eqn{Y} nodes (see Details).
 #' @param shape.node character vector of length two, the shape of the \eqn{X}

--- a/R/network.R
+++ b/R/network.R
@@ -653,7 +653,7 @@ network <- function(mat,
     
     #-- size.node
     if (!is.null(size.node)) {
-      if (!is.finite(size.node) || size.node < 0 || size.node > 1 || length(size.node)>1) {
+      if (!is.finite(size.node) || size.node < 0 || size.node > 1) {
         stop("'size.node' must be a numerical value between 0 - 1.", call. = FALSE)
       }
       if (size.node == 0) {
@@ -663,7 +663,7 @@ network <- function(mat,
     }
     
     #-- graph.scale
-    if (!is.finite(graph.scale) || graph.scale < 0 || graph.scale > 1 || length(graph.scale)>1) {
+    if (!is.finite(graph.scale) || graph.scale < 0 || graph.scale > 1) {
       stop("'graph.scale' must be a numerical value between 0 - 1.", call. = FALSE)
     }
     

--- a/R/network.R
+++ b/R/network.R
@@ -735,6 +735,11 @@ network <- function(mat,
     } else {
         if(is.null(shape.node))
             shape.node=c("circle", "rectangle")
+        if (length(shape.node)==1) {
+          if(shape.node=="none") {
+            shape.node=c("none", "none")
+          }
+        }
         
         if (!is.list(shape.node))
         {
@@ -1028,8 +1033,9 @@ network <- function(mat,
     plot(1:upr.bnd, 1:upr.bnd, type = "n", axes = FALSE, xlab = "", ylab = "")
     cha = V(gR)$label
     cha = paste("", cha, "")
-    xh = strwidth(cha, cex = ifelse(size.node==0.5, cex0, size.node*4)) * 1.5
-    yh = strheight(cha, cex = cex0) * 3
+    xh = strwidth(cha, cex = ifelse(size.node==0.5, cex0, size.node*4)) * 1.5 * (2-graph.scale)
+    yh = strheight(cha, cex = ifelse(size.node==0.5, cex0, size.node*4)) * 3 * (2-graph.scale)
+  
     
     V(gR)$size = xh
     V(gR)$size2 = yh

--- a/man/network.Rd
+++ b/man/network.Rd
@@ -16,10 +16,12 @@ network(
   row.names = TRUE,
   col.names = TRUE,
   block.var.names = TRUE,
+  graph.scale = 0.5,
+  size.node = 0.5,
   color.node = NULL,
   shape.node = NULL,
   alpha.node = 0.85,
-  cex.node.name = 1,
+  cex.node.name = NULL,
   color.edge = color.GreenRed(100),
   lty.edge = "solid",
   lwd.edge = 1,
@@ -57,6 +59,13 @@ and \eqn{Y}-variables.}
 \item{block.var.names}{either a list of vector components for variable names
 in each block or FALSE for no names. If TRUE, the columns names of the
 blocks are used as names.}
+
+\item{graph.scale}{Numeric between 0 and 1 which alters the scale of the entire
+plot. Increasing the value decreases the size of nodes and increases their distance
+from one another. Defaults to 0.5.}
+
+\item{size.node}{Numeric between 0 and 1 which determines the relative size of nodes.
+Defaults to 0.5.}
 
 \item{color.node}{vector of length two, the colors of the \eqn{X} and
 \eqn{Y} nodes (see Details).}


### PR DESCRIPTION
This PR contains numerous changes to the `network()` function. Users noted that a lack of control over vertex size and distances made for difficulty in plotting. Vertices frequently overlapped, covering the edges completely - essentially nullifying the purpose of the figure. The following changes were made:

- Added `graph.scale` parameter: influences the scale of the entire network. Increasing this value essentially "zooms out" from the plot, decreasing vertex size and proximity. 
  - Range: 0-1, 
  - Default: 0.5 (`network()` functions the same as prior to PR)
- Added `size.node` parameter: influences the size of the vertices. Works independently from `graph.scale`.   
  - Range: 0-1, 
  - Default: 0.5 (`network()` functions the same as prior to PR)
- If user sets `shape.node == "none"`, then the vertex labels will be coloured in the same fashion as the vertices would be. 
- Cleaned up some of the checks for various parameter and ensured minmal chance of warnings/errors occuring when using `network()` on different objects
- Added tests to maintain coverage
- Updated documentation and SemVer

