### PR TITLE
Fix for Issue #237

### DIFF
--- a/R/plotVar.R
+++ b/R/plotVar.R
@@ -453,6 +453,11 @@ plotVar <-
         if (any(sapply(cord.X, nrow) == 0))
             stop("No variable selected on at least one block")
         
+        if (any(sapply(cord.X, nrow) == 1)) {
+          cord.X <- cord.X[-which(sapply(cord.X, nrow) == 1)]
+        }
+          
+        
         #-- End: Retrieve variates from object
         
         #-- Names of labels X and Y

--- a/R/selectVar.R
+++ b/R/selectVar.R
@@ -137,6 +137,7 @@ selectVar.rgcca <- selectVar.mixo_pls
 get.name.and.value <- function(x,comp)
 {
     value <- data.frame(value.var = x[,comp])
+    rownames(value) <- rownames(x)
     value <- value[abs(value$value.var) > .Machine$double.eps,,drop=FALSE]
     value <- value[order(-abs(value$value.var)),,drop=FALSE]
     

--- a/tests/testthat/test-plotVar.R
+++ b/tests/testthat/test-plotVar.R
@@ -42,7 +42,7 @@ test_that("plotVar works in block.(s)PLS1 cases", {
                                  keepX = list(miRNA=c(3,3),
                                               mRNA=c(3,3)))
   
-  plotVar.result <- plotVar(block.pls.result)
+  plotVar.result <- plotVar(block.pls.result, plot = FALSE)
   
   expect_equal(as.character(unique(plotVar.result$Block)), c("miRNA", "mRNA"))
 })

--- a/tests/testthat/test-plotVar.R
+++ b/tests/testthat/test-plotVar.R
@@ -27,3 +27,22 @@ test_that("plotVar works for pls with var.names", {
   expect_true(all(df$names %in% as.character(unlist(var.names))))
   
 })
+
+test_that("plotVar works in block.(s)PLS1 cases", {
+  
+  data(breast.TCGA)
+  X <- list(miRNA = breast.TCGA$data.train$mirna[,1:10],
+            mRNA = breast.TCGA$data.train$mrna[,1:10])
+  
+  Y <- matrix(breast.TCGA$data.train$protein[,4], ncol=1)
+  rownames(Y) <- rownames(X$miRNA)
+  colnames(Y) <- "response"
+  
+  block.pls.result <- block.spls(X, Y, design = "full",
+                                 keepX = list(miRNA=c(3,3),
+                                              mRNA=c(3,3)))
+  
+  plotVar.result <- plotVar(block.pls.result)
+  
+  expect_equal(as.character(unique(plotVar.result$Block)), c("miRNA", "mRNA"))
+})


### PR DESCRIPTION
Addresses issue raised in [this forum post](https://mixomics-users.discourse.group/t/no-variable-selected-on-at-least-one-block-error/1000/3).

Adjusted `get.name.and.value()` to ensure names of selected values are retained. Also added check in `plotVar()` to remove the single Y feature from `cord.X` as this is unnecessary to plot. This is due to the single Y feature always having correlation of -1 or 1 with all components