### PR TITLE
239 custom maintainer credentials for bioc push workflow

### DIFF
--- a/.github/workflows/push2bioc.yml
+++ b/.github/workflows/push2bioc.yml
@@ -1,4 +1,10 @@
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Type 'yes' to push. Otherwise, only diff with remote is shown."
+        required: true
+        default: "show diff only"
 
 name: "Push to Bioconductor"
 
@@ -34,7 +40,11 @@ jobs:
           #--- push
           git fetch --all # for logs in case of failure
           current_branch=${{ github.ref_name }}
-          git push bioc $current_branch:$current_branch
+          if [  "${{ github.event.inputs.push }}" == "yes" ]; then
+            git push bioc $current_branch:$current_branch
+          else
+            git diff $current_branch -- bioc/$current_branch
+          fi
         env:
           SSH_KEY: ${{ secrets.PRIVATE_SSH_KEY_BIOC_MAINTAINER }}
           BIOC_HOST: ${{ secrets.BIOC_HOST }}

--- a/.github/workflows/push2bioc.yml
+++ b/.github/workflows/push2bioc.yml
@@ -28,16 +28,18 @@ jobs:
           ssh-keyscan $BIOC_HOST > ~/.ssh/known_hosts
           cd $wd
           #--- git config
-          git config user.name 'Al J Abadi'
-          git config user.email 'al.jal.abadi@gmail.com'
+          git config user.name '$MAINTAINER_NAME'
+          git config user.email '$MAINTAINER_EMAIL'
           git remote add bioc git@git.bioconductor.org:packages/mixOmics.git
           #--- push
           git fetch --all # for logs in case of failure
           current_branch=${{ github.ref_name }}
           git push bioc $current_branch:$current_branch
         env:
-          SSH_KEY: ${{ secrets.PRIVATE_SSH_KEY_AL }}
+          SSH_KEY: ${{ secrets.PRIVATE_SSH_KEY_BIOC_MAINTAINER }}
           BIOC_HOST: ${{ secrets.BIOC_HOST }}
+          MAINTAINER_NAME: ${{ secrets.MAINTAINER_NAME }}
+          MAINTAINER_EMAIL: ${{ secrets.MAINTAINER_EMAIL }}
 
       - name: Upload Logs
         if: always()


### PR DESCRIPTION
This change improves the workflow that allows pushing to Bioconductor's remote from GitHub. See #239 for details.