### PR TITLE
Fix for Issue #264

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -50,18 +50,18 @@ jobs:
             bioc="devel"
             r="$r_devel"
           fi
-          echo ::set-output name=r::$r
-          echo ::set-output name=bioc::$bioc
+          echo "r=$r" >> $GITHUB_OUTPUT
+          echo "bioc=$bioc" >> $GITHUB_OUTPUT
 
           ## Docker
           # Only Dockerise for 'master' or 'RELEASE_*' branches
           dockerise='false'
           [[ github.event_name != 'schedule' && ($BRANCH_NAME == "master" || $BRANCH_NAME =~ "release_") ]] && dockerise='true'
-          echo ::set-output name=dockerise::$dockerise
+          echo "dockerise=$dockerise" >> $GITHUB_OUTPUT
           # Docker tag is 'github' for master and the branch name for release branches
           docker_tag="github"
           [[ $BRANCH_NAME =~ "release_" ]] && docker_tag=$BRANCH_NAME
-          echo ::set-output name=docker_tag::$docker_tag
+          echo "docker_tag=$docker_tag" >> $GITHUB_OUTPUT
 
   R-CMD-check:
     needs: [gatekeeper, versions]

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -33,7 +33,7 @@ jobs:
       docker_tag: ${{ steps.setup.outputs.docker_tag }}
     steps:
       - uses: rlespinasse/github-slug-action@v3.x
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
       - name: Get R/Bioc versions
         id: setup
         run: |
@@ -91,7 +91,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up R ▶️
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         if: matrix.config.image == null
         with:
           r-version: ${{ matrix.config.r }}


### PR DESCRIPTION
`set-output` commands will be depreciated. Four calls to this command in `Get R/Bioc versions` action updated to resolve warning