### PR TITLE
Fix for Issue #266

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -405,6 +405,9 @@ predict.mixo_pls <-
                     newdata[which(!is.na(ind.match))] = lapply(which(!is.na(ind.match)), function(x){sweep(newdata[[x]], 2, STATS = attr(X[[x]], "scaled:center"))})
                 if (scale)
                     newdata[which(!is.na(ind.match))] = lapply(which(!is.na(ind.match)), function(x){sweep(newdata[[x]], 2, FUN = "/", STATS = attr(X[[x]], "scaled:scale"))})
+                if (any(unlist(lapply(newdata[which(!is.na(ind.match))], function(x){any(is.infinite(x))})))) {
+                  newdata[which(!is.na(ind.match))] <- lapply(which(!is.na(ind.match)), function(x){df <- newdata[[x]]; df[which(is.infinite(df))] <- NaN; return(df)})
+                }
                 
                 means.Y = matrix(attr(Y, "scaled:center"),nrow=nrow(newdata[[1]]),ncol=q,byrow=TRUE);
                 if (scale)

--- a/tests/testthat/test-auroc.R
+++ b/tests/testthat/test-auroc.R
@@ -21,3 +21,27 @@ test_that("auroc works", {
     rbind(0.9981, 7.124e-09))
 
  })
+
+
+
+test_that("Safely handles zero var (non-zero center) features", {
+  
+  X1 <- data.frame(matrix(rnorm(100000, 5, 5), nrow = 100))
+  X2 <- data.frame(matrix(rnorm(150000, 5, 5), nrow = 100))
+  Y <- c(rep("A", 50), rep("B", 50))
+  
+  X <- list(block1=X1, block2=X2)
+  
+  list.keepX <- list(block1=c(15, 15), block2=c(30,30))
+  
+  X$block1[,1] <- rep(1, 100)
+  model = suppressWarnings(block.splsda(X = X, Y = Y, ncomp = 2,
+                                        keepX = list.keepX, design = "full"))
+  
+  set.seed(9425)
+  auc.splsda = .quiet(auroc(model))
+  
+  .expect_numerically_close(auc.splsda$block1$comp1[[1]], 0.815)
+  .expect_numerically_close(auc.splsda$block2$comp2[[2]], 2.22e-16)
+  
+})


### PR DESCRIPTION
While the error that resulted in this PR was raised by `auroc()`, the issue stems from the `predict()` function. 

Lack of more explicit warning against near zero variance features in `block.splsda()` will be address in separate PR.

For framework presented in reprex in associated GitHub Issue ([here](https://github.com/mixOmicsTeam/mixOmics/issues/266)). 

Take a given feature in one of the predictor blocks. If it's all 0s:

- Centered and scaled in `block.splsda()`. Results in same all zero vector as center = 0, scale = 0.
- `object$X` used as `newdata` parameter for `predict()` call in `auroc()`
- within `predict()`, 0 values have 0 subtracted from them (centered) are divided by 0 (scaling), resulting in `NaN` in those predictor values. (In R, `0/0 == NaN`)
- `NaN`s can be handled safely (ignored) by the remainder of the function, resulting in valid predictions.

If that feature are all the same non-zero value (eg. all equal to 1):

- Centered and scaled in `block.splsda()`. Results in all zero vector but center = 1, scale = 0. Stored in `object$X`
- `object$X` used as `newdata` parameter for `predict()` call in `auroc()`
- - within `predict()`, 0 values have 1 subtracted from them (centered) are divided by 0 (scaling), resulting in `Inf` in those predictor values. (In R, `1/0 == Inf`)
- `Inf`s CANNOT be handled safely by the remainder of the function, causing all predictions made on that block to be `NaN`. This results in downstream issues (like the error raised by `auroc() -> statauc() -> roc.default() -> roc.utils.perfs.fast.all.threshold() -> cut()

Hence, when the `newdata` parameter is centered and scaled using attributes of `object$X`, function now checks if any of the values are not finite. If so, then `Inf` or `-Inf` are replaced by `NaN`