### PR TITLE
PR addressing Issue #275

### DIFF
--- a/R/tune.spca.R
+++ b/R/tune.spca.R
@@ -62,6 +62,12 @@ tune.spca <- function(X,
     
     all.keepX <- test.keepX
     names(all.keepX) <- paste0('keepX_', all.keepX)
+    
+    if (any(is.na(X))) {
+      X[which(is.na(X))] <- 0
+      warning("There were NAs present in the input dataframe. These were converted to 0 values. If you don't want these as 0, handle missing values prior to tuning.", call. = F)
+    }
+    
     ## ------ component loop
     for(ncomp in seq_len(ncomp)) {
         iter_keepX <- function(keepX.value) {

--- a/R/tune.spca.R
+++ b/R/tune.spca.R
@@ -84,16 +84,15 @@ tune.spca <- function(X,
                         # loop to calculate deflated matrix and predicted comp
                         # calculate the predicted comp on the fold left out
                         # calculate reg coeff, then deflate
-                        if(k == 1){
-                            t.comp.pred = X.test %*% spca.train$loadings$X[,k]
-                        } else{
-                            # calculate deflation beyond comp 1
-                            # recalculate the loading vector (here c.sub) on the test set (perhaps we could do this instead on the training set by extracting from spca.train$loadings$X[,k]?)
-                            c.sub = crossprod(X.test, t.comp.pred) / drop(crossprod(t.comp.pred)) 
-                            X.test = X.test - t.comp.pred %*% t(c.sub) 
-                            # update predicted comp based on deflated matrix
-                            t.comp.pred = X.test %*% spca.train$loadings$X[,k]
-                        }
+                        if(k != 1){
+                          # calculate deflation beyond comp 1
+                          # recalculate the loading vector (here c.sub) on the test set 
+                          # (perhaps we could do this instead on the training set by extracting from spca.train$loadings$X[,k]?)
+                          c.sub = crossprod(X.test, t.comp.pred) / drop(crossprod(t.comp.pred)) 
+                          X.test = X.test - t.comp.pred %*% t(c.sub) 
+                          # update predicted comp based on deflated matrix
+                        } 
+                      t.comp.pred = X.test %*% spca.train$loadings$X[,k]
                     }
                     # calculate predicted component and compare with component from sPCA on full data on the left out set
                     # cor with the component on the full data, abs value

--- a/tests/testthat/test-tune.spca.R
+++ b/tests/testthat/test-tune.spca.R
@@ -1,0 +1,43 @@
+
+test_that("tune.spca works", {
+  
+  set.seed(5212)
+  
+  data(srbct)
+  X <- srbct$gene[1:20, 1:200]
+  
+  grid.keepX <- seq(5, 35, 10)
+  
+  object <- tune.spca(X,ncomp = 2, 
+                      folds = 5, 
+                      test.keepX = grid.keepX, nrepeat = 3)
+  
+  expect_equal(object$choice.keepX[[1]], 35)
+  expect_equal(object$choice.keepX[[2]], 5)
+})
+
+test_that("tune.spca works with NA input", {
+  
+  set.seed(5212)
+  
+  data(srbct)
+  X <- srbct$gene[1:20, 1:200]
+  
+  na.feats <- sample(1:ncol(X), 20)
+  
+  for (c in na.feats) {
+    na.samples <- sample(1:nrow(X),1) #  sample.int(3, 1)
+    
+    X[na.samples, c] <- NA
+  }
+  
+  grid.keepX <- seq(5, 35, 10)
+  
+  expect_warning({object <- tune.spca(X,ncomp = 2, 
+                      folds = 5, 
+                      test.keepX = grid.keepX, nrepeat = 3)},
+                 "NAs present")
+  
+  expect_equal(object$choice.keepX[[1]], 15)
+  expect_equal(object$choice.keepX[[2]], 5)
+})

--- a/tests/testthat/test-tune.spca.R
+++ b/tests/testthat/test-tune.spca.R
@@ -12,8 +12,8 @@ test_that("tune.spca works", {
                       folds = 5, 
                       test.keepX = grid.keepX, nrepeat = 3)
   
-  expect_equal(object$choice.keepX[[1]], 35)
-  expect_equal(object$choice.keepX[[2]], 5)
+  expect_equal(object$choice.keepX[[1]], 25)
+  expect_equal(object$choice.keepX[[2]], 35)
 })
 
 test_that("tune.spca works with NA input", {
@@ -38,5 +38,5 @@ test_that("tune.spca works with NA input", {
                  "NAs present")
   
   expect_equal(object$choice.keepX[[1]], 15)
-  expect_equal(object$choice.keepX[[2]], 5)
+  expect_equal(object$choice.keepX[[2]], 25)
 })

--- a/tests/testthat/test-tune.spca.R
+++ b/tests/testthat/test-tune.spca.R
@@ -1,13 +1,13 @@
 
 test_that("tune.spca works", {
   
-  set.seed(5212)
   
   data(srbct)
   X <- srbct$gene[1:20, 1:200]
   
   grid.keepX <- seq(5, 35, 10)
   
+  set.seed(5212)
   object <- tune.spca(X,ncomp = 2, 
                       folds = 5, 
                       test.keepX = grid.keepX, nrepeat = 3)
@@ -17,8 +17,6 @@ test_that("tune.spca works", {
 })
 
 test_that("tune.spca works with NA input", {
-  
-  set.seed(5212)
   
   data(srbct)
   X <- srbct$gene[1:20, 1:200]
@@ -33,7 +31,8 @@ test_that("tune.spca works with NA input", {
   
   grid.keepX <- seq(5, 35, 10)
   
-  expect_warning({object <- tune.spca(X,ncomp = 2, 
+  expect_warning({set.seed(5212)
+                  object <- tune.spca(X,ncomp = 2, 
                       folds = 5, 
                       test.keepX = grid.keepX, nrepeat = 3)},
                  "NAs present")


### PR DESCRIPTION
As written in the associated Issue, presence of `NA`s in `X` parameter of `tune.spca()` was resulting in ambiguous error.

This PR includes a slight refactoring of some of the source code, as well as a check at the start of the function. If there are `NA`s, they are replaced with 0 and a warning is raised informing users of this imputation. Additionally, added new test file for `tune.spca()` to ensure coverage is maintained