### PR TITLE
PR addressing Issue #279

### DIFF
--- a/tests/testthat/test-tune.spca.R
+++ b/tests/testthat/test-tune.spca.R
@@ -7,13 +7,14 @@ test_that("tune.spca works", {
   
   grid.keepX <- seq(5, 35, 10)
   
-  RNGversion(.mixo_rng())
   set.seed(5212)
   object <- tune.spca(X,ncomp = 2, 
                       folds = 5, 
-                      test.keepX = grid.keepX, nrepeat = 3)
+                      test.keepX = grid.keepX, nrepeat = 3,
+                      BPPARAM = SerialParam(RNGseed = 5212))
   
   expect_equal(object$choice.keepX[[1]], 35)
+  expect_equal(object$choice.keepX[[2]], 5)
 })
 
 
@@ -22,6 +23,7 @@ test_that("tune.spca works with NA input", {
   data(srbct)
   X <- srbct$gene[1:20, 1:200]
   
+  set.seed(5212)
   na.feats <- sample(1:ncol(X), 20)
   
   for (c in na.feats) {
@@ -34,6 +36,10 @@ test_that("tune.spca works with NA input", {
   
   expect_warning({object <- tune.spca(X,ncomp = 2, 
                                       folds = 5, 
-                                      test.keepX = grid.keepX, nrepeat = 3)},
+                                      test.keepX = grid.keepX, nrepeat = 3,
+                                      BPPARAM = SerialParam(RNGseed = 5212))},
                  "NAs present")
+  
+  expect_equal(object$choice.keepX[[1]], 15)
+  expect_equal(object$choice.keepX[[2]], 5)
 })


### PR DESCRIPTION
With any function which utilises the `bplapply()` function internally contains (or at least should contain) a `BPPARAM` parameter. We can set the `RNGseed` parameter of `SerialParam()` (or any other `BiocParallel` function) to control the RNG. This allows for us to have consistent output in unit tests