### PR TITLE
PR addressing Issue #284

### DIFF
--- a/R/auroc.R
+++ b/R/auroc.R
@@ -192,6 +192,7 @@ auroc.list <-
     # initialise returned objects
     auc.list <- list()
     df <- data.frame(matrix(NA, nrow=0, ncol=4))
+    Specificity <- Sensitivity <- Outcome <-  model <- NULL
     
     for (idx in seq_len(length(object))) { # for each model
       

--- a/R/check_entry.R
+++ b/R/check_entry.R
@@ -204,17 +204,9 @@ Check.entry.pls = function(X, Y, ncomp, keepX, keepY, test.keepX, test.keepY,
     
     # if DA and the unmapped Y has rows without associated class
     if (DA) {
-      Y.tmp <- NULL
-      if (missing(Y)) {
-        Y.tmp <- X[[indY]]
-      } else {
-        Y.tmp <- Y
-      }
-      
-      if (length(which(rowSums(Y.tmp)==0)) != 0) {
+      if (length(which(rowSums(Y)==0)) != 0) {
         stop("Unmapped Y contains samples with no associated class. May be caused by NAs in input Y vector")
       }
-      rm(Y.tmp)
     }
     
     if(!is.null(multilevel))


### PR DESCRIPTION
`indY` used in `check_entry.pls()` but is not defined nor passed in as a parameter. Lines [206-218](https://github.com/mixOmicsTeam/mixOmics/blob/51846ea84c510c64cc03c3c6bd6ba10e361083e9/R/check_entry.R#L206) is location of this call. These lines were tested, and are unnecessary - including the `[[indY]]` call, hence this `if()` statement was condensed.

The four features of `df` in `auroc.list()` were defined as `NULL` upon initialization to resolve note.