### PR TITLE
PR addressing Issue #286

### DIFF
--- a/R/perf.R
+++ b/R/perf.R
@@ -561,7 +561,7 @@ perf.mixo_spls  <- perf.mixo_pls
             u.cv = spls.res$variates$Y[, 1]
             t.cv = spls.res$variates$X[, 1]
             a.cv = spls.res$loadings$X[, 1]
-            b.cv = spls.res$loadings$Y[, 1]
+            b.cv = spls.res$loadings$Y[, 1, drop = F]
             
             # reg coefficients:
             c.cv = crossprod(X.train, u.cv) / drop(crossprod(u.cv)) 


### PR DESCRIPTION
fix: added call to `drop` parameter to force the `b.cv` variable to remain a dataframe, even if 1x1.