### PR TITLE
Bioc fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mixOmics
 Type: Package
 Title: Omics Data Integration Project
-Version: 6.23.4
+Version: 6.23.5
 Depends: R (>= 3.5.0), 
          MASS, 
          lattice, 

--- a/vignettes/vignette.Rmd
+++ b/vignettes/vignette.Rmd
@@ -680,14 +680,14 @@ We can analyse these two data sets (genes and clinical measurements) using sPLS1
 
 ## Load the data {#04:load-data}
 
-```{r 04-load-data2, echo = FALSE}
+```{r 04-load-data2, echo = FALSE, eval = FALSE}
 devtools::install_github("mixOmicsTeam/mixOmics")
 data(liver.toxicity)
 X <- liver.toxicity$gene
 Y <- liver.toxicity$clinic
 ```
 
-```{r 04-load-data, eval = FALSE}
+```{r 04-load-data, eval = TRUE}
 library(mixOmics)
 data(liver.toxicity)
 X <- liver.toxicity$gene


### PR DESCRIPTION
(bug) Dependencies failing on Bioc 3.18. Due to devtools call. Removing this block from evaluation