### PR TITLE
add tests for tune.spca reflecting reproducibility and parallelisation

### DIFF
--- a/tests/testthat/test-tune.spca.R
+++ b/tests/testthat/test-tune.spca.R
@@ -1,37 +1,59 @@
 
-test_that("tune.spca works", {
-  
-  
+test_that("tune.spca works in serial and parallel", {
   data(srbct)
   X <- srbct$gene[1:20, 1:200]
-  
   grid.keepX <- seq(5, 35, 10)
-  
-  set.seed(5212)
-  object <- tune.spca(X,ncomp = 2, 
+  set.seed(5212) # set here although this actually doesnt affect tune.spca
+  object_serial <- tune.spca(X,ncomp = 2, 
                       folds = 5, 
                       test.keepX = grid.keepX, nrepeat = 3,
                       BPPARAM = SerialParam(RNGseed = 5212))
-  
-  expect_equal(object$choice.keepX[[1]], 35)
-  expect_equal(object$choice.keepX[[2]], 5)
+  expect_equal(object_serial$choice.keepX[[1]], 35)
+  expect_equal(object_serial$choice.keepX[[2]], 5)
+  .expect_numerically_close(object_serial$cor.comp$comp1[1,2], 0.3994544)
+  object_parallel <- tune.spca(X,ncomp = 2, 
+                      folds = 5, 
+                      test.keepX = grid.keepX, nrepeat = 3,
+                      BPPARAM = MulticoreParam(RNGseed = 5212))
+  expect_equal(object_parallel$choice.keepX[[1]], 35)
+  expect_equal(object_parallel$choice.keepX[[2]], 5)
+  .expect_numerically_close(object_parallel$cor.comp$comp1[1,2], 0.3994544)
 })
 
-
-test_that("tune.spca works with NA input", {
-  
+test_that("tune.spca is faster in parallel", {
   data(srbct)
   X <- srbct$gene[1:20, 1:200]
-  
-  set.seed(5212)
+  grid.keepX <- seq(5, 35, 10)
+  set.seed(5212) # set here although this actually doesnt affect tune.spca
+  serial_time <- system.time(
+    object_serial <- tune.spca(X,ncomp = 2, 
+                               folds = 5, 
+                               test.keepX = grid.keepX, nrepeat = 20,
+                               BPPARAM = SerialParam(RNGseed = 5212))
+  )
+  parallel_time <- system.time(
+    object_parallel <- tune.spca(X,ncomp = 2, 
+                               folds = 5, 
+                               test.keepX = grid.keepX, nrepeat = 20,
+                               BPPARAM = MulticoreParam(RNGseed = 5212))
+  )
+  # expect parallel faster
+  expect_true(serial_time[3] > parallel_time[3])
+  # expect results the same
+  expect_equal(object_parallel$choice.keepX[[1]], object_serial$choice.keepX[[1]])
+  expect_equal(object_parallel$choice.keepX[[2]], object_serial$choice.keepX[[2]])
+  .expect_numerically_close(object_parallel$cor.comp$comp1[3,3], object_serial$cor.comp$comp1[3,3])
+})
+
+test_that("tune.spca works with NA input", {
+  data(srbct)
+  X <- srbct$gene[1:20, 1:200]
+  set.seed(5212) # set here although this actually doesnt affect tune.spca
   na.feats <- sample(1:ncol(X), 20)
-  
   for (c in na.feats) {
     na.samples <- sample(1:nrow(X),1) #  sample.int(3, 1)
-    
     X[na.samples, c] <- NA
   }
-  
   grid.keepX <- seq(5, 35, 10)
   
   expect_warning({object <- tune.spca(X,ncomp = 2, 
@@ -39,7 +61,6 @@ test_that("tune.spca works with NA input", {
                                       test.keepX = grid.keepX, nrepeat = 3,
                                       BPPARAM = SerialParam(RNGseed = 5212))},
                  "NAs present")
-  
   expect_equal(object$choice.keepX[[1]], 15)
   expect_equal(object$choice.keepX[[2]], 5)
 })


### PR DESCRIPTION
have identified that `tune.spca` is reproducible if `RNGseed` is set in the `BPPARAM` argument. Have added testing to better assess this function in serial and in parallel