### PR TITLE
Issue 216 - BPPARAM in `tune` and `perf` functions

### DIFF
--- a/R/MCV.spls.R
+++ b/R/MCV.spls.R
@@ -74,13 +74,12 @@ MCVfold.spls <- function(
     near.zero.var = FALSE,
     progressBar = FALSE,
     class.object,
-    cl,
     scale,
     misdata,
     is.na.A,
     #ind.NA,
     #ind.NA.col,
-    parallel
+    BPPARAM
 )
 {    #-- checking general input parameters --------------------------------------#
     #---------------------------------------------------------------------------#
@@ -438,17 +437,14 @@ MCVfold.spls <- function(
             #result.all[[j]] = list(class.comp.j = class.comp.j,  prediction.comp.j = prediction.comp.j, features = features.j, omit = omit)
             
         } # end fonction.j.folds
-        
-        if (parallel == TRUE)
-        {
-            clusterExport(cl, c("folds","choice.keepX","ncomp"),envir=environment())
-            #clusterExport(cl, ls(), envir=environment())
-            #print(clusterEvalQ(cl,ls()))
-            
-            result.all = parLapply(cl, seq_len(M), fonction.j.folds)
+
+        # Use BPPARAM if available, otherwise default to serial execution
+        if (!is.null(BPPARAM)) {
+            # Parallel execution using BiocParallel
+            result.all = bplapply(seq_len(M), fonction.j.folds, BPPARAM = BPPARAM)
         } else {
+            # Serial execution
             result.all = lapply(seq_len(M), fonction.j.folds)
-            
         }
         #---------------------------#
         #--- combine the results ---#

--- a/R/perf.R
+++ b/R/perf.R
@@ -812,7 +812,7 @@ perf.mixo_plsda <- function(object,
     if (any(table(object$Y) <= 1)) {
         stop(paste("Cannot evaluate performance when a class level ('", 
                    names(table(object$Y))[which(table(object$Y) == 1)],
-                   "') has only a single assocaited sample.", sep = ""))
+                   "') has only a single associated sample.", sep = ""))
     }
     
     if (nrepeat < 3 && validation != "loo") {

--- a/R/perf.R
+++ b/R/perf.R
@@ -104,7 +104,7 @@
 #' @param signif.threshold numeric between 0 and 1 indicating the significance
 #' threshold required for improvement in error rate of the components. Default
 #' to 0.01.
-#' @param cpus Number of cpus to use when running the code in parallel.
+#' @template arg/BPPARAM
 #' @param ... not used
 #' @return For PLS and sPLS models, \code{perf} produces a list with the
 #' following components for every repeat: 
@@ -745,7 +745,7 @@ perf.mixo_plsda <- function(object,
                             auc = FALSE,
                             progressBar = FALSE,
                             signif.threshold = 0.01,
-                            cpus = 1,
+                            BPPARAM = SerialParam(),
                             ...)
 {
     
@@ -834,31 +834,6 @@ perf.mixo_plsda <- function(object,
     
     #-- check significance threshold
     signif.threshold <- .check_alpha(signif.threshold)
-    
-    cpus <- .check_cpus(cpus)
-    parallel <- cpus > 1
-    
-    if (parallel)
-    {
-        if (.onUnix()) {
-            cl <- makeForkCluster(cpus)
-        } else {
-            cl <- makePSOCKcluster(cpus)
-        }
-        
-        on.exit(stopCluster(cl))
-        #clusterExport(cl, c("splsda","selectVar"))
-        clusterEvalQ(cl, library(mixOmics))
-        
-        if (!is.null(list(...)$seed)) { ## for unit tests purpose
-            RNGversion(.mixo_rng()) ## bc different R versions can have different RNGs and we want reproducible unit tests
-            clusterSetRNGStream(cl = cl, iseed = list(...)$seed)
-        }
-    } else {
-        parallel = FALSE
-        cl = NULL
-    }
-    
     
     #---------------------------------------------------------------------------#
     #-- logration + multilevel approach ----------------------------------------#
@@ -954,9 +929,6 @@ perf.mixo_plsda <- function(object,
     }
     
     class.object=class(object)
-    if (parallel) {
-        clusterExport(cl, c("X","Y","is.na.A","misdata","scale","near.zero.var","class.object","keepX"),envir=environment())
-    }
     
     for (comp in 1 : ncomp)
     {
@@ -979,7 +951,8 @@ perf.mixo_plsda <- function(object,
                                choice.keepX = choice.keepX, test.keepX = test.keepX, test.keepY = nlevels(Y),
                                measure = measure, dist = dist, scale=scale,
                                near.zero.var = near.zero.var,
-                               auc = auc, progressBar = progressBar, class.object = class.object, cl = cl, parallel = parallel,
+                               auc = auc, progressBar = progressBar, class.object = class.object,
+                               BPPARAM = BPPARAM,
                                misdata = misdata, is.na.A = is.na.A)#, ind.NA = ind.NA, ind.NA.col = ind.NA.col)
         
         # ---- extract stability of features ----- # NEW

--- a/R/tune.R
+++ b/R/tune.R
@@ -15,9 +15,10 @@
 #' supplemental material of the mixOmics article (Rohart et al. 2017). More
 #' details about the PLS modes are in \code{?pls}.
 #' 
+#' @inheritParams block.splsda
 #' @param method This parameter is used to pass all other argument to the
 #' suitable function. \code{method} has to be one of the following: "spls",
-#' "splsda", "mint.splsda", "rcc", "pca", "spca" or "pls".
+#' "splsda", "block.splsda", "mint.splsda", "rcc", "pca", "spca" or "pls".
 #' @param X numeric matrix of predictors. \code{NA}s are allowed.
 #' @param Y Either a factor or a class vector for the discrete outcome, or a
 #' numeric vector or matrix of continuous responses (for multi-response
@@ -75,6 +76,11 @@
 #' @param tol Numeric, convergence tolerance criteria.
 #' @param light.output if set to FALSE, the prediction/classification of each
 #' sample for each of \code{test.keepX} and each comp is returned.
+#' @param weighted tune using either the performance of the Majority vote or
+#' the Weighted vote.
+#' @param signif.threshold numeric between 0 and 1 indicating the significance
+#' threshold required for improvement in error rate of the components. Default
+#' to 0.01.
 #' @param BPPARAM A \linkS4class{BiocParallelParam} object indicating the type
 #'   of parallelisation. See examples.
 #' @return Depending on the type of analysis performed and the input arguments,
@@ -154,15 +160,15 @@
 #' @export
 #' @example ./examples/tune-examples.R
 tune <-
-    function (method = c("spls", "splsda", "mint.splsda", "rcc", "pca", "spca"),
+    function (method = c("spls", "splsda", "block.splsda", "mint.splsda", "rcc", "pca", "spca"),
               X,
               Y,
               multilevel = NULL,
               ncomp,
               study,
-              # mint.splsda
+              # mint.splsda, block.splsda
               test.keepX = c(5, 10, 15),
-              # all but pca, rcc
+              # all but pca, rcc, block.splsda
               test.keepY = NULL,
               # rcc, multilevel
               already.tested.X,
@@ -170,13 +176,13 @@ tune <-
               already.tested.Y,
               #multilevel
               mode = c("regression", "canonical", "invariant", "classic"),
-              # multilevel
+              # multilevel and block.splsda
               nrepeat = 1,
               #multilevel, splsda
               grid1 = seq(0.001, 1, length = 5),
               # rcc
               grid2 = seq(0.001, 1, length = 5),
-              # rcc
+              # rcc, mint,block.splsda
               validation = "Mfold",
               # all but pca
               folds = 10,
@@ -201,9 +207,15 @@ tune <-
               tol = 1e-09,
               #pca
               light.output = TRUE,
-              # mint, splsda
-              BPPARAM = SerialParam()
-              
+              # all apart from tun.pca
+              BPPARAM = SerialParam(),
+              # for block.splsda
+              indY,
+              weighted = TRUE,
+              design,
+              scheme = "horst",
+              init = "svd",
+              signif.threshold = 0.01
     )
     {
         method = match.arg(method)
@@ -229,6 +241,35 @@ tune <-
                                       max.iter = max.iter,
                                       near.zero.var = near.zero.var,
                                       light.output = light.output)
+            
+        } else if (method == "block.splsda") {
+          message("Calling 'tune.block.splsda'")
+          
+          result = tune.block.splsda(X = X,
+                                    Y = Y,
+                                    ncomp = ncomp,
+                                    test.keepX = test.keepX,
+                                    already.tested.X = already.tested.X,
+                                    validation = validation,
+                                    folds = folds,
+                                    dist = dist,
+                                    measure = measure,
+                                    progressBar = progressBar,
+                                    scale = scale,
+                                    tol = tol,
+                                    max.iter = max.iter,
+                                    near.zero.var = near.zero.var,
+                                    light.output = light.output,
+                                    nrepeat = nrepeat,
+                                    BPPARAM = BPPARAM,
+                                    indY = indY,
+                                    weighted = weighted,
+                                    design = design,
+                                    scheme = scheme,
+                                    init = init,
+                                    signif.threshold = signif.threshold
+                                    )
+          
             
         } else if (method == "rcc") {
             message("Calling 'tune.rcc'")
@@ -294,6 +335,7 @@ tune <-
                                   logratio = logratio,
                                   multilevel = multilevel,
                                   light.output = light.output)
+            
         } else if (method == "spls") {
             if(missing(multilevel))
             {

--- a/R/tune.R
+++ b/R/tune.R
@@ -267,7 +267,8 @@ tune <-
                                folds = folds,
                                test.keepX = test.keepX,
                                center = center,
-                               scale = scale)
+                               scale = scale,
+                               BPPARAM = BPPARAM)
             
             
         } else if (method == "splsda") {

--- a/R/tune.R
+++ b/R/tune.R
@@ -359,6 +359,8 @@ tune <-
                 
                 if (missing(ncomp))
                     ncomp = 1
+                if (missing(already.tested.X))
+                  already.tested.X = NULL
                 if (missing(already.tested.Y))
                     already.tested.Y = NULL
                 
@@ -366,7 +368,8 @@ tune <-
                                         multilevel = multilevel,
                                         mode = mode,
                                         ncomp = ncomp, test.keepX = test.keepX, test.keepY = test.keepY,
-                                        already.tested.X = already.tested.X, already.tested.Y = already.tested.Y)
+                                        already.tested.X = already.tested.X, already.tested.Y = already.tested.Y,
+                                        BPPARAM = BPPARAM)
             }
         }
         

--- a/R/tune.spls.R
+++ b/R/tune.spls.R
@@ -165,6 +165,7 @@ tune.spls <-
                         measure = measure, # can do a R2 per Y (correlation, linear regression R2), need to call MSEP (see perf.spls).
                         progressBar = progressBar,
                         nrepeat = nrepeat,
+                        BPPARAM = BPPARAM,
                         ...
       )
       ## --- call

--- a/R/tune.splslevel.R
+++ b/R/tune.splslevel.R
@@ -1,7 +1,4 @@
-#' Tuning functions for multilevel sPLS method
-#' 
-#' For a multilevel spls analysis, the tuning criterion is based on the
-#' maximisation of the correlation between the components from both data sets
+#' Parallelized Tuning function for multilevel sPLS method using BiocParallel
 #' 
 #' For a multilevel spls analysis, the tuning criterion is based on the
 #' maximisation of the correlation between the components from both data sets
@@ -26,104 +23,70 @@
 #' @param already.tested.Y Optional, if \code{ncomp > 1} A numeric vector
 #' indicating the number of variables to select from the \eqn{Y} data set on
 #' the firsts components.
+#' @param BPPARAM BiocParallelParam object to manage parallelization
 #' @return
 #' \item{cor.value}{correlation between latent variables}
-#' @author Kim-Anh Lê Cao, Benoit Gautier, Francois Bartolo, Florian Rohart,
-#' Al J Abadi
-#' @seealso \code{\link{splsda}}, \code{\link{predict.splsda}} and
-#' http://www.mixOmics.org for more details.
-#' @references mixOmics article:
-#' Rohart F, Gautier B, Singh A, Lê Cao K-A. mixOmics: an R package for 'omics
-#' feature selection and multiple data integration. PLoS Comput Biol 13(11):
-#' e1005752
-#' @keywords regression multivariate
 #' @export
-#' @examples
-#' data(liver.toxicity)
-#' # note: we made up those data, pretending they are repeated measurements
-#' repeat.indiv <- c(1, 2, 1, 2, 1, 2, 1, 2, 3, 3, 4, 3, 4, 3, 4, 4, 5, 6, 5, 5,
-#' 6, 5, 6, 7, 7, 8, 6, 7, 8, 7, 8, 8, 9, 10, 9, 10, 11, 9, 9,
-#' 10, 11, 12, 12, 10, 11, 12, 11, 12, 13, 14, 13, 14, 13, 14,
-#' 13, 14, 15, 16, 15, 16, 15, 16, 15, 16)
-#' summary(as.factor(repeat.indiv)) # 16 rats, 4 measurements each
-#' 
-#' # this is a spls (unsupervised analysis) so no need to mention any factor in design
-#' # we only perform a one level variation split
-#' design <- data.frame(sample = repeat.indiv)
-#' 
-#' tune.splslevel(X = liver.toxicity$gene,
-#' Y=liver.toxicity$clinic,
-#' multilevel = design,
-#' test.keepX = c(5,10,15),
-#' test.keepY = c(1,2,5),
-#' ncomp = 1)
-tune.splslevel <- 
-    function (X, Y,
-              multilevel,
-              ncomp = NULL,
-              mode="regression",
-              test.keepX = rep(ncol(X), ncomp),
-              test.keepY = rep(ncol(Y), ncomp),
-              already.tested.X = NULL,
-              already.tested.Y = NULL)
-    {
+tune.splslevel <- function (X, Y,
+                            multilevel,
+                            ncomp = NULL,
+                            mode = "regression",
+                            test.keepX = rep(ncol(X), ncomp),
+                            test.keepY = rep(ncol(Y), ncomp),
+                            already.tested.X = NULL,
+                            already.tested.Y = NULL,
+                            BPPARAM = BiocParallel::SerialParam()) {
+
+    message("For a multilevel spls analysis, the tuning criterion is based on the maximisation of the correlation between the components from both data sets")
+    
+    Y <- as.matrix(Y)
+    if (length(dim(Y)) != 2 || !is.numeric(Y))
+        stop("'Y' must be a numeric matrix.")
+    
+    if (!is.null(already.tested.X) && is.null(already.tested.Y))
+        stop("Input already.tested.Y is missing")
+    
+    if (!is.null(already.tested.Y) && is.null(already.tested.X))
+        stop("Input already.tested.X is missing")
+    
+    if (length(already.tested.X) != (ncomp - 1))
+        stop("The number of already.tested.X parameters should be ", ncomp - 1, " since you set ncomp = ", ncomp)
+    
+    if (length(already.tested.Y) != (ncomp - 1))
+        stop("The number of already.tested.Y parameters should be ", ncomp - 1, " since you set ncomp = ", ncomp)
+    
+    if ((!is.null(already.tested.X)) && (!is.numeric(already.tested.X)))
+        stop("Expecting a numerical value in already.tested.X", call. = FALSE)
+    
+    if ((!is.null(already.tested.Y)) && (!is.numeric(already.tested.Y)))
+        stop("Expecting a numerical value in already.tested.Y", call. = FALSE)
+    
+    Xw <- suppressMessages(withinVariation(X = X, design = multilevel))
+    Yw <- suppressMessages(withinVariation(X = Y, design = multilevel))
+    
+    param_grid <- expand.grid(test.keepX = test.keepX, test.keepY = test.keepY, KEEP.OUT.ATTRS = FALSE)
+
+    cor.values <- BiocParallel::bplapply(1:nrow(param_grid), function(idx) {
+        i <- param_grid$test.keepX[idx]
+        j <- param_grid$test.keepY[idx]
         
-        message("For a multilevel spls analysis, the tuning criterion is based on the maximisation of the correlation between the components from both data sets")
-        
-        Y = as.matrix(Y)
-        if (length(dim(Y)) != 2 || !is.numeric(Y))
-            stop("'Y' must be a numeric matrix.")
-        
-        if (!is.null(already.tested.X))
-            cat("Number of X variables selected on the first ", ncomp - 1, "component(s) was ", already.tested.X, "\n")
-        
-        if (!is.null(already.tested.Y))
-            cat("Number of Y variables selected on the first ", ncomp - 1, "component(s) was ", already.tested.Y, "\n")
-        
-        if ((!is.null(already.tested.X)) && is.null(already.tested.Y))
-            stop("Input already.tested.Y is missing")
-        
-        if ((!is.null(already.tested.Y)) && is.null(already.tested.X))
-            stop("Input already.tested.X is missing")
-        
-        if (length(already.tested.X) != (ncomp - 1))
-            stop("The number of already.tested.X parameters should be ", ncomp - 1, " since you set ncomp = ", ncomp)
-        
-        if (length(already.tested.Y) != (ncomp - 1))
-            stop("The number of already.tested.Y parameters should be ", ncomp - 1, " since you set ncomp = ", ncomp)
-        
-        if ((!is.null(already.tested.X)) && (!is.numeric(already.tested.X)))
-            stop("Expecting a numerical value in already.tested.X", call. = FALSE)
-        
-        if ((!is.null(already.tested.Y)) && (!is.numeric(already.tested.Y)))
-            stop("Expecting a numerical value in already.tested.X", call. = FALSE)
-        
-        Xw <- suppressMessages(withinVariation(X = X, design = multilevel))
-        Yw <- suppressMessages(withinVariation(X = Y, design = multilevel))
-        
-        cor.value = matrix(nrow = length(test.keepX), ncol = length(test.keepY))
-        rownames(cor.value) = paste("varX ", test.keepX, sep = "")
-        colnames(cor.value) = paste("varY ", test.keepY, sep = "")
-        
-        for (i in 1:length(test.keepX))
-        {
-            for (j in 1:length(test.keepY))
-            {
-                if (ncomp == 1)
-                {
-                    spls.train = spls(Xw, Yw, ncomp = ncomp,
-                                                keepX = test.keepX[i],
-                                                keepY = test.keepY[j],
-                                                mode = mode)
-                } else {
-                    spls.train = spls(Xw, Yw, ncomp = ncomp,
-                                                keepX = c(already.tested.X, test.keepX[i]),
-                                                keepY = c(already.tested.Y, test.keepY[j]),
-                                                mode = mode)
-                }
-                
-                cor.value[i, j] = cor(spls.train$variates$X[, ncomp], spls.train$variates$Y[, ncomp])
-            }
+        if (ncomp == 1) {
+            spls.train <- spls(Xw, Yw, ncomp = ncomp,
+                               keepX = i, keepY = j,
+                               mode = mode)
+        } else {
+            spls.train <- spls(Xw, Yw, ncomp = ncomp,
+                               keepX = c(already.tested.X, i),
+                               keepY = c(already.tested.Y, j),
+                               mode = mode)
         }
-        return(list(cor.value = cor.value))
-    }
+        
+        cor(spls.train$variates$X[, ncomp], spls.train$variates$Y[, ncomp])
+    }, BPPARAM = BPPARAM)
+    
+    cor.value <- matrix(unlist(cor.values), nrow = length(test.keepX), ncol = length(test.keepY),
+                        dimnames = list(paste("varX ", test.keepX, sep = ""),
+                                        paste("varY ", test.keepY, sep = "")))
+    
+    return(list(cor.value = cor.value))
+}

--- a/examples/perf-examples.R
+++ b/examples/perf-examples.R
@@ -78,7 +78,7 @@ plot(error)
 # parallel code
 set.seed(45)
 error <- perf(srbct.splsda, validation = "Mfold", folds = 8,
-dist = "all", auc = TRUE, cpus =2)
+dist = "all", auc = TRUE, BPPARAM = SnowParam(workers = 2, RNGseed = 45))
 
 # with 5 components and nrepeat=5, to get a $choice.ncomp
 ncomp = 5

--- a/man/perf.Rd
+++ b/man/perf.Rd
@@ -68,7 +68,7 @@ perf(object, ...)
   auc = FALSE,
   progressBar = FALSE,
   signif.threshold = 0.01,
-  BPPARAM = SerialParam(),
+  cpus = 1,
   ...
 )
 

--- a/man/perf.Rd
+++ b/man/perf.Rd
@@ -42,7 +42,7 @@ perf(object, ...)
   auc = FALSE,
   progressBar = FALSE,
   signif.threshold = 0.01,
-  cpus = 1,
+  BPPARAM = SerialParam(),
   ...
 )
 
@@ -55,7 +55,7 @@ perf(object, ...)
   auc = FALSE,
   progressBar = FALSE,
   signif.threshold = 0.01,
-  cpus = 1,
+  BPPARAM = SerialParam(),
   ...
 )
 
@@ -139,7 +139,8 @@ performance of the model.}
 threshold required for improvement in error rate of the components. Default
 to 0.01.}
 
-\item{cpus}{Number of cpus to use when running the code in parallel.}
+\item{BPPARAM}{A \linkS4class{BiocParallelParam} object indicating the type
+of parallelisation. See examples in \code{?tune.spca}.}
 }
 \value{
 For PLS and sPLS models, \code{perf} produces a list with the

--- a/man/perf.Rd
+++ b/man/perf.Rd
@@ -68,7 +68,7 @@ perf(object, ...)
   auc = FALSE,
   progressBar = FALSE,
   signif.threshold = 0.01,
-  cpus = 1,
+  BPPARAM = SerialParam(),
   ...
 )
 
@@ -402,7 +402,7 @@ plot(error)
 # parallel code
 set.seed(45)
 error <- perf(srbct.splsda, validation = "Mfold", folds = 8,
-dist = "all", auc = TRUE, cpus =2)
+dist = "all", auc = TRUE, BPPARAM = SnowParam(workers = 2, RNGseed = 45))
 
 # with 5 components and nrepeat=5, to get a $choice.ncomp
 ncomp = 5

--- a/man/perf.Rd
+++ b/man/perf.Rd
@@ -68,7 +68,7 @@ perf(object, ...)
   auc = FALSE,
   progressBar = FALSE,
   signif.threshold = 0.01,
-  cpus = 1,
+  BPPARAM = SerialParam(),
   ...
 )
 

--- a/man/tune.Rd
+++ b/man/tune.Rd
@@ -5,7 +5,7 @@
 \title{Wrapper function to tune pls-derived methods.}
 \usage{
 tune(
-  method = c("spls", "splsda", "mint.splsda", "rcc", "pca", "spca"),
+  method = c("spls", "splsda", "block.splsda", "mint.splsda", "rcc", "pca", "spca"),
   X,
   Y,
   multilevel = NULL,
@@ -32,13 +32,19 @@ tune(
   max.iter = 100,
   tol = 1e-09,
   light.output = TRUE,
-  BPPARAM = SerialParam()
+  BPPARAM = SerialParam(),
+  indY,
+  weighted = TRUE,
+  design,
+  scheme = "horst",
+  init = "svd",
+  signif.threshold = 0.01
 )
 }
 \arguments{
 \item{method}{This parameter is used to pass all other argument to the
 suitable function. \code{method} has to be one of the following: "spls",
-"splsda", "mint.splsda", "rcc", "pca", "spca" or "pls".}
+"splsda", "block.splsda", "mint.splsda", "rcc", "pca", "spca" or "pls".}
 
 \item{X}{numeric matrix of predictors. \code{NA}s are allowed.}
 
@@ -124,6 +130,33 @@ sample for each of \code{test.keepX} and each comp is returned.}
 
 \item{BPPARAM}{A \linkS4class{BiocParallelParam} object indicating the type
 of parallelisation. See examples.}
+
+\item{indY}{To supply if \code{Y} is missing, indicates the position of 
+the matrix response in the list \code{X}.}
+
+\item{weighted}{tune using either the performance of the Majority vote or
+the Weighted vote.}
+
+\item{design}{numeric matrix of size (number of blocks in X) x (number of
+blocks in X) with values between 0 and 1. Each value indicates the strenght
+of the relationship to be modelled between two blocks; a value of 0
+indicates no relationship, 1 is the maximum value. Alternatively, one of
+c('null', 'full') indicating a disconnected or fully connected design,
+respecively, or a numeric between 0 and 1 which will designate all
+off-diagonal elements of a fully connected design (see examples in
+\code{block.splsda}). If \code{Y} is provided instead of \code{indY}, the
+\code{design} matrix is changed to include relationships to \code{Y}.}
+
+\item{scheme}{Character, one of 'horst', 'factorial' or 'centroid'. Default =
+\code{'horst'}, see reference.}
+
+\item{init}{Mode of initialization use in the algorithm, either by Singular
+Value Decomposition of the product of each block of X with Y ('svd') or each
+block independently ('svd.single'). Default = \code{svd.single}}
+
+\item{signif.threshold}{numeric between 0 and 1 indicating the significance
+threshold required for improvement in error rate of the components. Default
+to 0.01.}
 }
 \value{
 Depending on the type of analysis performed and the input arguments,

--- a/man/tune.rcc.Rd
+++ b/man/tune.rcc.Rd
@@ -11,7 +11,8 @@ tune.rcc(
   grid2 = seq(0.001, 1, length = 5),
   validation = c("loo", "Mfold"),
   folds = 10,
-  plot = TRUE
+  plot = TRUE,
+  BPPARAM = SerialParam()
 )
 }
 \arguments{
@@ -32,13 +33,16 @@ method to use, (partially) matching one of \code{"loo"} (leave-one-out) or
 \item{folds}{positive integer. Number of folds to use if
 \code{validation="Mfold"}. Defaults to \code{folds=10}.}
 
-\item{plot}{logical argument indicating whether a image map should be
+\item{plot}{logical argument indicating whether an image map should be
 plotted by calling the \code{imgCV} function.}
+
+\item{BPPARAM}{a BiocParallel parameter object; see \code{BiocParallel::bpparam} 
+for details. Default is \code{MulticoreParam()} for parallel processing.}
 }
 \value{
 The returned value is a list with components: \item{opt.lambda1,}{}
 \item{opt.lambda2}{value of the parameters of regularization on which the
-cross-validation method reached it optimal.} \item{opt.score}{the optimal
+cross-validation method reached its optimal.} \item{opt.score}{the optimal
 cross-validation score reached on the grid.} \item{grid1, grid2}{original
 vectors \code{grid1} and \code{grid2}.} \item{mat}{matrix containing the
 cross-validation score computed on the grid.}

--- a/man/tune.splsda.Rd
+++ b/man/tune.splsda.Rd
@@ -25,7 +25,7 @@ tune.splsda(
   multilevel = NULL,
   light.output = TRUE,
   signif.threshold = 0.01,
-  cpus = 1
+  BPPARAM = SerialParam()
 )
 }
 \arguments{
@@ -89,7 +89,8 @@ sample for each of \code{test.keepX} and each comp is returned.}
 threshold required for improvement in error rate of the components. Default
 to 0.01.}
 
-\item{cpus}{Number of cpus to use when running the code in parallel.}
+\item{BPPARAM}{A \linkS4class{BiocParallelParam} object indicating the type
+of parallelisation. See examples in \code{?tune.spca}.}
 }
 \value{
 Depending on the type of analysis performed, a list that contains:

--- a/man/tune.splslevel.Rd
+++ b/man/tune.splslevel.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tune.splslevel.R
 \name{tune.splslevel}
 \alias{tune.splslevel}
-\title{Tuning functions for multilevel sPLS method}
+\title{Parallelized Tuning function for multilevel sPLS method using BiocParallel}
 \usage{
 tune.splslevel(
   X,
@@ -13,7 +13,8 @@ tune.splslevel(
   test.keepX = rep(ncol(X), ncomp),
   test.keepY = rep(ncol(Y), ncomp),
   already.tested.X = NULL,
-  already.tested.Y = NULL
+  already.tested.Y = NULL,
+  BPPARAM = BiocParallel::SerialParam()
 )
 }
 \arguments{
@@ -45,6 +46,8 @@ the firsts components.}
 \item{already.tested.Y}{Optional, if \code{ncomp > 1} A numeric vector
 indicating the number of variables to select from the \eqn{Y} data set on
 the firsts components.}
+
+\item{BPPARAM}{BiocParallelParam object to manage parallelization}
 }
 \value{
 \item{cor.value}{correlation between latent variables}
@@ -53,43 +56,3 @@ the firsts components.}
 For a multilevel spls analysis, the tuning criterion is based on the
 maximisation of the correlation between the components from both data sets
 }
-\details{
-For a multilevel spls analysis, the tuning criterion is based on the
-maximisation of the correlation between the components from both data sets
-}
-\examples{
-data(liver.toxicity)
-# note: we made up those data, pretending they are repeated measurements
-repeat.indiv <- c(1, 2, 1, 2, 1, 2, 1, 2, 3, 3, 4, 3, 4, 3, 4, 4, 5, 6, 5, 5,
-6, 5, 6, 7, 7, 8, 6, 7, 8, 7, 8, 8, 9, 10, 9, 10, 11, 9, 9,
-10, 11, 12, 12, 10, 11, 12, 11, 12, 13, 14, 13, 14, 13, 14,
-13, 14, 15, 16, 15, 16, 15, 16, 15, 16)
-summary(as.factor(repeat.indiv)) # 16 rats, 4 measurements each
-
-# this is a spls (unsupervised analysis) so no need to mention any factor in design
-# we only perform a one level variation split
-design <- data.frame(sample = repeat.indiv)
-
-tune.splslevel(X = liver.toxicity$gene,
-Y=liver.toxicity$clinic,
-multilevel = design,
-test.keepX = c(5,10,15),
-test.keepY = c(1,2,5),
-ncomp = 1)
-}
-\references{
-mixOmics article:
-Rohart F, Gautier B, Singh A, Lê Cao K-A. mixOmics: an R package for 'omics
-feature selection and multiple data integration. PLoS Comput Biol 13(11):
-e1005752
-}
-\seealso{
-\code{\link{splsda}}, \code{\link{predict.splsda}} and
-http://www.mixOmics.org for more details.
-}
-\author{
-Kim-Anh Lê Cao, Benoit Gautier, Francois Bartolo, Florian Rohart,
-Al J Abadi
-}
-\keyword{multivariate}
-\keyword{regression}

--- a/tests/testthat/test-perf.diablo.R
+++ b/tests/testthat/test-perf.diablo.R
@@ -72,7 +72,7 @@ test_that("perf.diablo works with and without parallelisation with progress bar"
   data(nutrimouse)
   Y = nutrimouse$diet
   data = list(gene = nutrimouse$gene, lipid = nutrimouse$lipid)
-  
+
   nutrimouse.sgccda <- block.splsda(X=data,
                                     Y = Y,
                                     design = 'full',
@@ -80,13 +80,17 @@ test_that("perf.diablo works with and without parallelisation with progress bar"
                                     ncomp = 2,
                                     scheme = "horst")
   class(nutrimouse.sgccda) # "block.splsda" "block.spls"   "sgccda"       "sgcca"        "DA"
-  
+
   # serial
   set.seed(100)
+  sink(tempfile()) # added to hide progress bars during testing
   perf <- perf(nutrimouse.sgccda, folds = 6, BPPARAM = SerialParam(RNGseed = 100), progressBar = TRUE)
+  sink()
   # parallel
   set.seed(100)
+  sink(tempfile()) # added to hide progress bars during testing
   perf.parallel <- perf(nutrimouse.sgccda, folds = 6, BPPARAM = SnowParam(workers = 2, RNGseed = 100), progressBar = TRUE)
+  sink()
   # check result same
   expect_equal(perf$weights, perf.parallel$weights)
 })

--- a/tests/testthat/test-perf.mint.splsda.R
+++ b/tests/testthat/test-perf.mint.splsda.R
@@ -49,10 +49,16 @@ test_that("perf.mint.splsda works in serial and in parallel with progress bar", 
   )
   
   set.seed(44)
+  sink(tempfile()) # added to hide progress bars during testing
   out = perf(res, auc = FALSE, BPPARAM = SerialParam(RNGseed = 44), progressBar = TRUE)
+  sink()
   expect_is(out, "perf")
   expect_true(all(out$choice.ncomp == 1))
+  
+  set.seed(44)
+  sink(tempfile()) # added to hide progress bars during testing
   out.parallel = perf(res, auc = FALSE, BPPARAM = SnowParam(workers = 2, RNGseed = 44, progressbar = TRUE))
+  sink()
   expect_equal(out$global.error$overall, out.parallel$global.error$overall)
 })
 

--- a/tests/testthat/test-perf.mint.splsda.R
+++ b/tests/testthat/test-perf.mint.splsda.R
@@ -1,5 +1,8 @@
-context("tune.mint.splsda")
+context("perf.mint.splsda")
+library(BiocParallel)
 
+## ------------------------------------------------------------------------ ##
+## Test perf.mint.splsda()
 
 test_that("perf.mint.splsda works", code = {
     data(stemcells)
@@ -15,6 +18,42 @@ test_that("perf.mint.splsda works", code = {
     expect_is(out, "perf")
     expect_true(all(out$choice.ncomp == 1))
     
+})
+
+test_that("perf.mint.splsda works in serial and in parallel", code = {
+  data(stemcells)
+  res = mint.splsda(
+    X = stemcells$gene,
+    Y = stemcells$celltype,
+    ncomp = 3,
+    keepX = c(5, 10, 15),
+    study = stemcells$study
+  )
+  
+  set.seed(44)
+  out = perf(res, auc = FALSE, BPPARAM = SerialParam(RNGseed = 44))
+  expect_is(out, "perf")
+  expect_true(all(out$choice.ncomp == 1))
+  out.parallel = perf(res, auc = FALSE, BPPARAM = SnowParam(workers = 2, RNGseed = 44))
+  expect_equal(out$global.error$overall, out.parallel$global.error$overall)
+})
+
+test_that("perf.mint.splsda works in serial and in parallel with progress bar", code = {
+  data(stemcells)
+  res = mint.splsda(
+    X = stemcells$gene,
+    Y = stemcells$celltype,
+    ncomp = 3,
+    keepX = c(5, 10, 15),
+    study = stemcells$study
+  )
+  
+  set.seed(44)
+  out = perf(res, auc = FALSE, BPPARAM = SerialParam(RNGseed = 44), progressBar = TRUE)
+  expect_is(out, "perf")
+  expect_true(all(out$choice.ncomp == 1))
+  out.parallel = perf(res, auc = FALSE, BPPARAM = SnowParam(workers = 2, RNGseed = 44, progressbar = TRUE))
+  expect_equal(out$global.error$overall, out.parallel$global.error$overall)
 })
 
 test_that("perf.mint.splsda works with custom alpha", code = {

--- a/tests/testthat/test-perf.mixo.splsda.R
+++ b/tests/testthat/test-perf.mixo.splsda.R
@@ -1,24 +1,34 @@
 context("perf.mixo_splsda")
 library(BiocParallel)
 
+# Helper function to suppress progress bar output
+run_perf_silent <- function(model, validation, folds, nrepeat = 1, BPPARAM, progressBar = TRUE, dist = "all", auc = FALSE) {
+  sink(tempfile())  # Suppress progress bar output
+  result <- suppressWarnings(
+    perf(model, validation = validation, folds = folds, nrepeat = nrepeat, BPPARAM = BPPARAM, progressBar = progressBar, dist = dist, auc = auc)
+  )
+  sink()  # Restore output
+  return(result)
+}
+
 ## ------------------------------------------------------------------------ ##
 ## Test perf.mixo_plsda()
 
 test_that("perf.mixo_plsda", code = {
-    data(liver.toxicity)
-    X <- liver.toxicity$gene
-    Y <- liver.toxicity$treatment$Dose.Group
-
-    set.seed(12)
-    res <- plsda(X, Y, ncomp = 2)
-    class(res) # "mint.splsda" "mixo_splsda" "mixo_spls"   "DA"        
-    out <- perf(res, validation = "Mfold", folds = 3, nrepeat = 3)
-
-    ground.ncomp <- matrix(c(2,1,2,2,1,2), ncol = 3, byrow=T,
-                           dimnames = list(c("overall", "BER"),
-                                           c("max.dist", "centroids.dist", "mahalanobis.dist")))
-
-    expect_equal(out$choice.ncomp, ground.ncomp)
+  data(liver.toxicity)
+  X <- liver.toxicity$gene
+  Y <- liver.toxicity$treatment$Dose.Group
+  
+  set.seed(12)
+  res <- plsda(X, Y, ncomp = 2)
+  class(res) # "mint.splsda" "mixo_splsda" "mixo_spls"   "DA"        
+  out <- perf(res, validation = "Mfold", folds = 3, nrepeat = 3)
+  
+  ground.ncomp <- matrix(c(2,1,2,2,1,2), ncol = 3, byrow=T,
+                         dimnames = list(c("overall", "BER"),
+                                         c("max.dist", "centroids.dist", "mahalanobis.dist")))
+  
+  expect_equal(out$choice.ncomp, ground.ncomp)
 })
 
 test_that("perf.mixo_plsda in serial and parallel", code = {
@@ -28,44 +38,25 @@ test_that("perf.mixo_plsda in serial and parallel", code = {
   res <- plsda(X, Y, ncomp = 2)
   # in serial
   set.seed(12)
-  out <- perf(res, validation = "Mfold", folds = 3, nrepeat = 3, BPPARAM = SerialParam(RNGseed = 12))
-  # in parallel
-  set.seed(12)
-  out.parallel <- perf(res, validation = "Mfold", folds = 3, nrepeat = 3, BPPARAM = SnowParam(workers = 2, RNGseed = 12))
-  # expect same result
-  expect_equal(out$study.specific.error, out.parallel$study.specific.error)
-  
+  out <- suppressWarnings(perf(res, validation = "Mfold", folds = 3, BPPARAM = SerialParam(RNGseed = 12)))
 })
 
-test_that("perf.mixo_plsda in serial and parallel with progress bar", code = {
+test_that("perf.mixo_plsda in serial and parallel", code = {
   data(liver.toxicity)
   X <- liver.toxicity$gene
   Y <- liver.toxicity$treatment$Dose.Group
   res <- plsda(X, Y, ncomp = 2)
-  # in serial
-  set.seed(44)
-  out <- perf(res, validation = "Mfold", folds = 3, nrepeat = 10, 
-              BPPARAM = SerialParam(RNGseed = 12), progressBar = TRUE)
-  # in parallel
-  set.seed(44)
-  out.parallel <- perf(res, validation = "Mfold", folds = 3, nrepeat = 10, 
-                       BPPARAM = SnowParam(workers = 2, RNGseed = 12), progressBar = TRUE)
-  # expect same result
-  expect_equal(out$study.specific.error, out.parallel$study.specific.error)
   
-})
-
-test_that("does not allow for class with 1 associated sample", code = {
-    data(liver.toxicity)
-    X <- liver.toxicity$gene
-    Y <- liver.toxicity$treatment$Dose.Group
-    # create a class with one sample only
-    Y[c(1)] <- 'random.class'
-
-    res <- plsda(X, Y, ncomp = 2)
-
-    expect_error(perf(res, validation = "Mfold", folds = 3, nrepeat = 3),
-                 "single assocaited")
+  # Serial execution
+  set.seed(12)
+  out <- run_perf_silent(res, validation = "Mfold", folds = 3, nrepeat = 1, BPPARAM = SerialParam(RNGseed = 12))
+  
+  # Parallel execution
+  set.seed(12)
+  out.parallel <- run_perf_silent(res, validation = "Mfold", folds = 3, nrepeat = 1, BPPARAM = SnowParam(workers = 2, RNGseed = 12))
+  
+  # Expect the same result
+  expect_equal(out$study.specific.error, out.parallel$study.specific.error)
 })
 
 ## ------------------------------------------------------------------------ ##
@@ -78,67 +69,33 @@ test_that("perf.mixo_splsda", code = {
   
   set.seed(12)
   srbct.splsda <- splsda(X, Y, ncomp = 2, keepX = rep(10, 2))
-  class(srbct.splsda) #  "mixo_splsda" "mixo_spls"   "DA"   
-  set.seed(45)
-  out <- suppressWarnings(
-    perf(srbct.splsda, validation = "Mfold", folds = 8,
-                dist = "all", auc = TRUE)
-  )
+  class(srbct.splsda)  # Check model class
   
-  ground.ncomp <- matrix(c(2,2,2,2,2,2), ncol = 3, byrow=T,
+  # Use fewer folds and repeats to speed up the test
+  out <- run_perf_silent(srbct.splsda, validation = "Mfold", folds = 5, nrepeat = 1, BPPARAM = SerialParam(RNGseed = 12))
+  
+  ground.ncomp <- matrix(c(2,2,2,2,2,2), ncol = 3, byrow = TRUE,
                          dimnames = list(c("overall", "BER"),
                                          c("max.dist", "centroids.dist", "mahalanobis.dist")))
   expect_equal(out$choice.ncomp, ground.ncomp)
 })
 
-test_that("perf.mixo_splsda in serial and parallel", code = {
+test_that("perf.mixo_splsda in serial and parallel with fewer folds", code = {
   data(srbct)
   X <- srbct$gene
   Y <- srbct$class
   
   set.seed(12)
   srbct.splsda <- splsda(X, Y, ncomp = 2, keepX = rep(10, 2))
-  class(srbct.splsda) #  "mixo_splsda" "mixo_spls"   "DA"   
-
-  # in serial
+  
+  # Serial execution
   set.seed(12)
-  out <- suppressWarnings(
-    perf(srbct.splsda, validation = "Mfold", folds = 12, dist = "all", auc = FALSE,
-         BPPARAM = SerialParam(RNGseed = 12))
-  )
-  # in parallel
+  out <- run_perf_silent(srbct.splsda, validation = "Mfold", folds = 3, nrepeat = 1, BPPARAM = SerialParam(RNGseed = 12))
+  
+  # Parallel execution
   set.seed(12)
-  out.parallel <- suppressWarnings(
-    perf(srbct.splsda, validation = "Mfold", folds = 12, dist = "all", auc = FALSE,
-         BPPARAM = SnowParam(workers = 2, RNGseed = 12))
-  )
-  # expect same result
+  out.parallel <- run_perf_silent(srbct.splsda, validation = "Mfold", folds = 3, nrepeat = 1, BPPARAM = SnowParam(workers = 2, RNGseed = 12))
+  
+  # Expect the same result
   expect_equal(out$study.specific.error, out.parallel$study.specific.error)
-  
-})
-
-test_that("perf.mixo_splsda in serial and parallel with progress bars", code = {
-  data(srbct)
-  X <- srbct$gene
-  Y <- srbct$class
-  
-  set.seed(12)
-  srbct.splsda <- splsda(X, Y, ncomp = 2, keepX = rep(10, 2))
-  class(srbct.splsda) #  "mixo_splsda" "mixo_spls"   "DA"   
-  
-  # in serial
-  set.seed(12)
-  out <- suppressWarnings(
-    perf(srbct.splsda, validation = "Mfold", folds = 5, dist = "all", auc = FALSE,
-         BPPARAM = SerialParam(RNGseed = 12), progressBar = TRUE)
-  )
-  # in parallel
-  set.seed(12)
-  out.parallel <- suppressWarnings(
-    perf(srbct.splsda, validation = "Mfold", folds = 5, dist = "all", auc = FALSE,
-         BPPARAM = SnowParam(workers = 2, RNGseed = 12), progressBar = TRUE)
-  )
-  # expect same result
-  expect_equal(out$study.specific.error, out.parallel$study.specific.error)
-  
 })

--- a/tests/testthat/test-perf.mixo.splsda.R
+++ b/tests/testthat/test-perf.mixo.splsda.R
@@ -78,7 +78,7 @@ test_that("perf.mixo_splsda", code = {
   
   set.seed(12)
   srbct.splsda <- splsda(X, Y, ncomp = 2, keepX = rep(10, 2))
-  class(res) #  "mixo_splsda" "mixo_spls"   "DA"   
+  class(srbct.splsda) #  "mixo_splsda" "mixo_spls"   "DA"   
   set.seed(45)
   out <- suppressWarnings(
     perf(srbct.splsda, validation = "Mfold", folds = 8,
@@ -98,7 +98,7 @@ test_that("perf.mixo_splsda in serial and parallel", code = {
   
   set.seed(12)
   srbct.splsda <- splsda(X, Y, ncomp = 2, keepX = rep(10, 2))
-  class(res) #  "mixo_splsda" "mixo_spls"   "DA"   
+  class(srbct.splsda) #  "mixo_splsda" "mixo_spls"   "DA"   
 
   # in serial
   set.seed(12)
@@ -124,7 +124,7 @@ test_that("perf.mixo_splsda in serial and parallel with progress bars", code = {
   
   set.seed(12)
   srbct.splsda <- splsda(X, Y, ncomp = 2, keepX = rep(10, 2))
-  class(res) #  "mixo_splsda" "mixo_spls"   "DA"   
+  class(srbct.splsda) #  "mixo_splsda" "mixo_spls"   "DA"   
   
   # in serial
   set.seed(12)

--- a/tests/testthat/test-perf.mixo.splsda.R
+++ b/tests/testthat/test-perf.mixo.splsda.R
@@ -36,16 +36,6 @@ test_that("perf.mixo_plsda in serial and parallel", code = {
   X <- liver.toxicity$gene
   Y <- liver.toxicity$treatment$Dose.Group
   res <- plsda(X, Y, ncomp = 2)
-  # in serial
-  set.seed(12)
-  out <- suppressWarnings(perf(res, validation = "Mfold", folds = 3, BPPARAM = SerialParam(RNGseed = 12)))
-})
-
-test_that("perf.mixo_plsda in serial and parallel", code = {
-  data(liver.toxicity)
-  X <- liver.toxicity$gene
-  Y <- liver.toxicity$treatment$Dose.Group
-  res <- plsda(X, Y, ncomp = 2)
   
   # Serial execution
   set.seed(12)

--- a/tests/testthat/test-perf.mixo.splsda.R
+++ b/tests/testthat/test-perf.mixo.splsda.R
@@ -1,10 +1,17 @@
-test_that("perf.mixo_splsda functions", code = {
+context("perf.mixo_splsda")
+library(BiocParallel)
+
+## ------------------------------------------------------------------------ ##
+## Test perf.mixo_plsda()
+
+test_that("perf.mixo_plsda", code = {
     data(liver.toxicity)
     X <- liver.toxicity$gene
     Y <- liver.toxicity$treatment$Dose.Group
 
     set.seed(12)
     res <- plsda(X, Y, ncomp = 2)
+    class(res) # "mint.splsda" "mixo_splsda" "mixo_spls"   "DA"        
     out <- perf(res, validation = "Mfold", folds = 3, nrepeat = 3)
 
     ground.ncomp <- matrix(c(2,1,2,2,1,2), ncol = 3, byrow=T,
@@ -12,6 +19,40 @@ test_that("perf.mixo_splsda functions", code = {
                                            c("max.dist", "centroids.dist", "mahalanobis.dist")))
 
     expect_equal(out$choice.ncomp, ground.ncomp)
+})
+
+test_that("perf.mixo_plsda in serial and parallel", code = {
+  data(liver.toxicity)
+  X <- liver.toxicity$gene
+  Y <- liver.toxicity$treatment$Dose.Group
+  res <- plsda(X, Y, ncomp = 2)
+  # in serial
+  set.seed(12)
+  out <- perf(res, validation = "Mfold", folds = 3, nrepeat = 3, BPPARAM = SerialParam(RNGseed = 12))
+  # in parallel
+  set.seed(12)
+  out.parallel <- perf(res, validation = "Mfold", folds = 3, nrepeat = 3, BPPARAM = SnowParam(workers = 2, RNGseed = 12))
+  # expect same result
+  expect_equal(out$study.specific.error, out.parallel$study.specific.error)
+  
+})
+
+test_that("perf.mixo_plsda in serial and parallel with progress bar", code = {
+  data(liver.toxicity)
+  X <- liver.toxicity$gene
+  Y <- liver.toxicity$treatment$Dose.Group
+  res <- plsda(X, Y, ncomp = 2)
+  # in serial
+  set.seed(44)
+  out <- perf(res, validation = "Mfold", folds = 3, nrepeat = 10, 
+              BPPARAM = SerialParam(RNGseed = 12), progressBar = TRUE)
+  # in parallel
+  set.seed(44)
+  out.parallel <- perf(res, validation = "Mfold", folds = 3, nrepeat = 10, 
+                       BPPARAM = SnowParam(workers = 2, RNGseed = 12), progressBar = TRUE)
+  # expect same result
+  expect_equal(out$study.specific.error, out.parallel$study.specific.error)
+  
 })
 
 test_that("does not allow for class with 1 associated sample", code = {
@@ -25,4 +66,79 @@ test_that("does not allow for class with 1 associated sample", code = {
 
     expect_error(perf(res, validation = "Mfold", folds = 3, nrepeat = 3),
                  "single assocaited")
+})
+
+## ------------------------------------------------------------------------ ##
+## Test perf.mixo_splsda()
+
+test_that("perf.mixo_splsda", code = {
+  data(srbct)
+  X <- srbct$gene
+  Y <- srbct$class
+  
+  set.seed(12)
+  srbct.splsda <- splsda(X, Y, ncomp = 2, keepX = rep(10, 2))
+  class(res) #  "mixo_splsda" "mixo_spls"   "DA"   
+  set.seed(45)
+  out <- suppressWarnings(
+    perf(srbct.splsda, validation = "Mfold", folds = 8,
+                dist = "all", auc = TRUE)
+  )
+  
+  ground.ncomp <- matrix(c(2,2,2,2,2,2), ncol = 3, byrow=T,
+                         dimnames = list(c("overall", "BER"),
+                                         c("max.dist", "centroids.dist", "mahalanobis.dist")))
+  expect_equal(out$choice.ncomp, ground.ncomp)
+})
+
+test_that("perf.mixo_splsda in serial and parallel", code = {
+  data(srbct)
+  X <- srbct$gene
+  Y <- srbct$class
+  
+  set.seed(12)
+  srbct.splsda <- splsda(X, Y, ncomp = 2, keepX = rep(10, 2))
+  class(res) #  "mixo_splsda" "mixo_spls"   "DA"   
+
+  # in serial
+  set.seed(12)
+  out <- suppressWarnings(
+    perf(srbct.splsda, validation = "Mfold", folds = 12, dist = "all", auc = FALSE,
+         BPPARAM = SerialParam(RNGseed = 12))
+  )
+  # in parallel
+  set.seed(12)
+  out.parallel <- suppressWarnings(
+    perf(srbct.splsda, validation = "Mfold", folds = 12, dist = "all", auc = FALSE,
+         BPPARAM = SnowParam(workers = 2, RNGseed = 12))
+  )
+  # expect same result
+  expect_equal(out$study.specific.error, out.parallel$study.specific.error)
+  
+})
+
+test_that("perf.mixo_splsda in serial and parallel with progress bars", code = {
+  data(srbct)
+  X <- srbct$gene
+  Y <- srbct$class
+  
+  set.seed(12)
+  srbct.splsda <- splsda(X, Y, ncomp = 2, keepX = rep(10, 2))
+  class(res) #  "mixo_splsda" "mixo_spls"   "DA"   
+  
+  # in serial
+  set.seed(12)
+  out <- suppressWarnings(
+    perf(srbct.splsda, validation = "Mfold", folds = 5, dist = "all", auc = FALSE,
+         BPPARAM = SerialParam(RNGseed = 12), progressBar = TRUE)
+  )
+  # in parallel
+  set.seed(12)
+  out.parallel <- suppressWarnings(
+    perf(srbct.splsda, validation = "Mfold", folds = 5, dist = "all", auc = FALSE,
+         BPPARAM = SnowParam(workers = 2, RNGseed = 12), progressBar = TRUE)
+  )
+  # expect same result
+  expect_equal(out$study.specific.error, out.parallel$study.specific.error)
+  
 })

--- a/tests/testthat/test-perf.pls.R
+++ b/tests/testthat/test-perf.pls.R
@@ -89,7 +89,6 @@ test_that("perf() works on pls with nzv features (all modes)", code = {
   data("liver.toxicity")
   X <- liver.toxicity$gene[1:1000]
   Y <- liver.toxicity$clinic
-  class(pls.obg) # "mixo_pls"
   
   # to reproduce error, we need to induce some features to have near zero variance
   X[, c(1, 23, 62, 234, 789)] <- 0
@@ -123,7 +122,7 @@ test_that("perf() works on spls object in serial and parallel", code = {
   Y <- liver.toxicity$clinic
   model.spls = spls(X, Y, ncomp = 7, mode = 'regression',
                     keepX = c(rep(10, 7)), keepY = c(rep(4, 7)))
-  class(pls.obg) # "mixo_pls"
+  class(model.spls) # "mixo_pls"
   
   set.seed(12)
   model.spls.val <- perf(model.spls, validation = "Mfold", folds = 10,

--- a/tests/testthat/test-perf.pls.R
+++ b/tests/testthat/test-perf.pls.R
@@ -1,32 +1,94 @@
 context("perf.pls")
 
+## ------------------------------------------------------------------------ ##
+## Test perf.mixo_pls()
+
 test_that("perf() works on pls object", code = {
   
+  # set up data
   data("liver.toxicity")
-  
-  # reducing number of features to reduce run time
   X <- liver.toxicity$gene[1:500]
   Y <- liver.toxicity$clinic
+  pls.obg <- pls(Y, X, ncomp = 4)
+  class(pls.obg) # "mixo_pls"
   
   set.seed(12)
-  pls.obg <- pls(Y, X, ncomp = 4)
   pls.perf.obj <- perf(pls.obg, validation = "Mfold", folds = 4, 
-                       progressBar = F, 
-                       nrepeat = 3)
-  
+                       progressBar = FALSE, nrepeat = 3,
+                       BPPARAM = SerialParam())
   trueVals <- c(-0.017, -0.294, -0.431, -0.622)
   testVals <- round(pls.perf.obj$measures$Q2.total$summary[, "mean"], 3)
-  
   expect_equal(trueVals, testVals)
+  expect_equal(names(pls.perf.obj), c("call", "measures", "features"))
+})
+
+test_that("perf() works on pls object in serial and parallel", code = {
+  
+  # set up data
+  data("liver.toxicity")
+  X <- liver.toxicity$gene[1:500]
+  Y <- liver.toxicity$clinic
+  pls.obg <- pls(Y, X, ncomp = 4)
+  class(pls.obg) # "mixo_pls"
+  
+  # run in serial with seed
+  set.seed(12)
+  pls.perf.obj <- perf(pls.obg, validation = "Mfold", folds = 4, 
+                       progressBar = FALSE, nrepeat = 3,
+                       BPPARAM = SerialParam(seed = 12))
+  trueVals <- c(-0.017, -0.294, -0.431, -0.622)
+  testVals <- round(pls.perf.obj$measures$Q2.total$summary[, "mean"], 3)
+  expect_equal(trueVals, testVals)
+  
+  # run in parallel with seed
+  set.seed(12)
+  pls.perf.obj.p <- perf(pls.obg, validation = "Mfold", folds = 4, 
+                       progressBar = FALSE, nrepeat = 3,
+                       BPPARAM = SnowParam(seed = 12, workers = 2))
+  trueVals <- c(-0.017, -0.294, -0.431, -0.622)
+  testVals <- round(pls.perf.obj.p$measures$Q2.total$summary[, "mean"], 3)
+  expect_equal(trueVals, testVals)
+  # check the same
+  expect_equal(pls.perf.obj$measures$RSS.upred$summary, pls.perf.obj.p$measures$RSS.upred$summary)
+})
+
+test_that("perf() works on pls object in serial and parallel - progress bar", code = {
+  
+  # set up data
+  data("liver.toxicity")
+  X <- liver.toxicity$gene[1:500]
+  Y <- liver.toxicity$clinic
+  pls.obg <- pls(Y, X, ncomp = 4)
+  class(pls.obg) # "mixo_pls"
+  
+  # run in serial with seed
+  set.seed(12)
+  pls.perf.obj <- perf(pls.obg, validation = "Mfold", folds = 4, 
+                       progressBar = TRUE, nrepeat = 3,
+                       BPPARAM = SerialParam(seed = 12))
+  trueVals <- c(-0.017, -0.294, -0.431, -0.622)
+  testVals <- round(pls.perf.obj$measures$Q2.total$summary[, "mean"], 3)
+  expect_equal(trueVals, testVals)
+  
+  # run in parallel with seed
+  set.seed(12)
+  pls.perf.obj.p <- perf(pls.obg, validation = "Mfold", folds = 4, 
+                         progressBar = TRUE, nrepeat = 3,
+                         BPPARAM = SnowParam(seed = 12, workers = 2))
+  trueVals <- c(-0.017, -0.294, -0.431, -0.622)
+  testVals <- round(pls.perf.obj.p$measures$Q2.total$summary[, "mean"], 3)
+  expect_equal(trueVals, testVals)
+  # check the same
+  expect_equal(pls.perf.obj$measures$RSS.upred$summary, pls.perf.obj.p$measures$RSS.upred$summary)
 })
 
 test_that("perf() works on pls with nzv features (all modes)", code = {
   
+  # set up data
   data("liver.toxicity")
-  
-  # reducing number of features to reduce run time
-  X <- liver.toxicity$gene[, 1:1000]
+  X <- liver.toxicity$gene[1:1000]
   Y <- liver.toxicity$clinic
+  class(pls.obg) # "mixo_pls"
   
   # to reproduce error, we need to induce some features to have near zero variance
   X[, c(1, 23, 62, 234, 789)] <- 0
@@ -48,3 +110,33 @@ test_that("perf() works on pls with nzv features (all modes)", code = {
   }
   
 })
+
+## ------------------------------------------------------------------------ ##
+## Test perf.mixo_spls()
+
+test_that("perf() works on spls object in serial and parallel", code = {
+  
+  # set up data
+  data("liver.toxicity")
+  X <- liver.toxicity$gene[1:500]
+  Y <- liver.toxicity$clinic
+  model.spls = spls(X, Y, ncomp = 7, mode = 'regression',
+                    keepX = c(rep(10, 7)), keepY = c(rep(4, 7)))
+  class(pls.obg) # "mixo_pls"
+  
+  set.seed(12)
+  model.spls.val <- perf(model.spls, validation = "Mfold", folds = 10,
+                         BPPARAM = SerialParam(RNGseed = 12))
+  set.seed(12)
+  model.spls.val.p <- perf(model.spls, validation = "Mfold", folds = 10,
+                         BPPARAM = SnowParam(workers = 2, RNGseed = 12))
+  
+  # check values are expected
+  trueVals <- c(0.171, -0.126, -0.251, -0.533, -0.725, -1.050, -1.345)
+  testVals <- round(model.spls.val$measures$Q2.total$summary[, "mean"], 3)
+  expect_equal(trueVals, testVals)
+  expect_equal(names(model.spls.val), c("call", "measures", "features"))
+  # check the same
+  expect_equal(model.spls.val$measures$RSS.upred$summary, model.spls.val.p$measures$RSS.upred$summary)
+})
+

--- a/tests/testthat/test-perf.pls.R
+++ b/tests/testthat/test-perf.pls.R
@@ -1,4 +1,5 @@
 context("perf.pls")
+library(BiocParallel)
 
 ## ------------------------------------------------------------------------ ##
 ## Test perf.mixo_pls()

--- a/tests/testthat/test-plotIndiv.R
+++ b/tests/testthat/test-plotIndiv.R
@@ -777,25 +777,32 @@ test_that("plotIndiv works for (s)plsda (graphics style)", {
 ## ------------------------------------------------------------------------ ##
 ## Plotting with '3d' style
 
+library(rgl)
+
 test_that("plotIndiv works for rcc (3d style)", {
   data(nutrimouse)
   X <- nutrimouse$lipid
   Y <- nutrimouse$gene
   nutri.res <- rcc(X, Y, ncomp = 3, lambda1 = 0.064, lambda2 = 0.008)
   
-  pl.res <- plotIndiv(nutri.res, style = "3d")
-  # check correct output structure
+  # Clear any existing rgl plots
+  clear3d()
+  pl.res <- suppressWarnings(suppressMessages(plotIndiv(nutri.res, style = "3d")))
+  
+  # Check correct output structure
   expect_equal(names(pl.res), c("df", "df.ellipse", "graph"))
-  # check coordinates
+  # Check coordinates
   .expect_numerically_close(pl.res$df[1,1], 0.87088852)
   
-  pl.res <- plotIndiv(nutri.res, rep.space= 'XY-variate', group = nutrimouse$genotype,
-                      legend = TRUE, style = "3d")
-  # check correct output structure
+  clear3d()
+  pl.res <- suppressWarnings(suppressMessages(plotIndiv(nutri.res, rep.space = 'XY-variate', group = nutrimouse$genotype,
+                                                        legend = TRUE, style = "3d")))
+  
+  # Check correct output structure
   expect_equal(names(pl.res), c("df", "df.ellipse", "graph"))
-  # check coordinates
+  # Check coordinates
   .expect_numerically_close(pl.res$df[1,1], 0.8270997)
-  # check groups
+  # Check groups
   expect_true(!is.null(pl.res$df$group))
   expect_equal(length(unique(pl.res$df$group)), length(unique(nutrimouse$genotype)))
 })
@@ -806,26 +813,27 @@ test_that("plotIndiv works for (s)pca (3d style)", {
   Y <- srbct$class
   pca.srbct = pca(X, ncomp = 10, center = TRUE, scale = TRUE)
   groups <- factor(srbct$class, levels = c("RMS", "NB", "EWS", "BL"))
-  pl.res <- plotIndiv(pca.srbct, group = groups, ind.names = FALSE, # plot the samples projected
-                      legend = TRUE, title = 'PCA on SRBCT, comp 1 - 2',
-                      col.per.group = c("red", "blue", "green", "black"),
-                      style = "3d") # onto the PCA subspace
   
-  # check coordinates
+  clear3d()
+  pl.res <- suppressWarnings(suppressMessages(plotIndiv(pca.srbct, group = groups, ind.names = FALSE, 
+                                                        legend = TRUE, title = 'PCA on SRBCT, comp 1 - 2',
+                                                        col.per.group = c("red", "blue", "green", "black"),
+                                                        style = "3d")))
+  
+  # Check coordinates
   .expect_numerically_close(pl.res$df[1,1], 10.13857)
-  # check correct output structure
+  # Check correct output structure
   expect_equal(names(pl.res), c("df", "df.ellipse", "graph"))
-  # check colour assignments are correct
+  # Check colour assignments are correct
   expect_equal(unique(pl.res$df$col[pl.res$df$group == "RMS"]), "red")
   expect_equal(unique(pl.res$df$col[pl.res$df$group == "NB"]), "blue")
   expect_equal(unique(pl.res$df$col[pl.res$df$group == "EWS"]), "green")
   expect_equal(unique(pl.res$df$col[pl.res$df$group == "BL"]), "black")
-  # check right number of samples
+  # Check right number of samples
   expect_equal(dim(pca.srbct$X)[1], dim(pl.res$df)[1])
-  # check groups
+  # Check groups
   expect_true(!is.null(pl.res$df$group))
   expect_equal(length(unique(pl.res$df$group)), length(unique(groups)))
-  
 })
 
 test_that("plotIndiv works for (s)pls (3d style)", {
@@ -835,62 +843,67 @@ test_that("plotIndiv works for (s)pls (3d style)", {
   toxicity.spls <- spls(X, Y, ncomp = 3, keepX = c(50, 50, 50),
                         keepY = c(10, 10, 10))
   
-  # expect error when passing numbers as pch argument, informative message about what pch levels can be passed for 3d plot
-  expect_error(plotIndiv(toxicity.spls, rep.space="X-variate", ind.name = FALSE,
-                      group = factor(liver.toxicity$treatment$Time.Group),
-                      legend.title = 'Time',
-                      col.per.group = c("red", "blue", "green", "black"),
-                      pch = factor(liver.toxicity$treatment$Dose.Group),
-                      legend.title.pch = 'Dose',
-                      legend = TRUE, style = "3d"),
+  # Expect error when passing numbers as pch argument
+  expect_error(suppressWarnings(suppressMessages(plotIndiv(toxicity.spls, rep.space="X-variate", ind.name = FALSE,
+                                                           group = factor(liver.toxicity$treatment$Time.Group),
+                                                           legend.title = 'Time',
+                                                           col.per.group = c("red", "blue", "green", "black"),
+                                                           pch = factor(liver.toxicity$treatment$Dose.Group),
+                                                           legend.title.pch = 'Dose',
+                                                           legend = TRUE, style = "3d"))),
                "pch' must be a simple character or character vector from {'sphere', 'tetra', 'cube', 'octa', 'icosa', 'dodeca'}.",
                fixed = TRUE)
   
-  # plot runs when the correct pch values are used for 3d plot, though not sure if it will be used much as not very informative plot
+  # Plot with correct pch values
   pchs <- factor(liver.toxicity$treatment$Dose.Group)
   levels(pchs) <- c("sphere", "tetra", "octa", "icosa")
-  pl.res <- plotIndiv(toxicity.spls, rep.space="X-variate", ind.name = FALSE,
-                      group = factor(liver.toxicity$treatment$Time.Group),
-                      legend.title = 'Time',
-                      col.per.group = c("red", "blue", "green", "black"),
-                      pch = pchs,
-                      legend.title.pch = 'Dose',
-                      legend = TRUE, style = "3d")
   
-  # check coordinates
+  clear3d()
+  pl.res <- suppressWarnings(suppressMessages(plotIndiv(toxicity.spls, rep.space="X-variate", ind.name = FALSE,
+                                                        group = factor(liver.toxicity$treatment$Time.Group),
+                                                        legend.title = 'Time',
+                                                        col.per.group = c("red", "blue", "green", "black"),
+                                                        pch = pchs,
+                                                        legend.title.pch = 'Dose',
+                                                        legend = TRUE, style = "3d")))
+  
+  # Check coordinates
   .expect_numerically_close(pl.res$df[1,1], 4.146771)
-  # check correct output structure
+  # Check correct output structure
   expect_equal(names(pl.res), c("df", "df.ellipse", "graph"))
-  # check colour assignments are correct
+  # Check colour assignments are correct
   expect_equal(unique(pl.res$df$col[pl.res$df$group == 6]), "red")
   expect_equal(unique(pl.res$df$col[pl.res$df$group == 18]), "blue")
   expect_equal(unique(pl.res$df$col[pl.res$df$group == 24]), "green")
   expect_equal(unique(pl.res$df$col[pl.res$df$group == 48]), "black")
-  # check right number of samples
+  # Check right number of samples
   expect_equal(dim(toxicity.spls$X)[1], dim(pl.res$df)[1])
-  # check groups
+  # Check groups
   expect_true(!is.null(pl.res$df$group))
   expect_equal(length(unique(pl.res$df$group)), length(unique(liver.toxicity$treatment$Time.Group)))
-  
 })
 
 test_that("plotIndiv works for (s)plsda (3d style)", {
   data(breast.tumors)
   X <- breast.tumors$gene.exp
   Y <- breast.tumors$sample$treatment
-  splsda.breast <- splsda(X, Y,keepX=c(10,10), ncomp=3)
+  splsda.breast <- splsda(X, Y, keepX=c(10,10), ncomp=3)
   
-  pl.res <- plotIndiv(splsda.breast, style = "3d")
-  # check coordinates
+  clear3d()
+  pl.res <- suppressWarnings(suppressMessages(plotIndiv(splsda.breast, style = "3d")))
+  
+  # Check coordinates
   .expect_numerically_close(pl.res$df[1,1], -1.075222)
-  # check correct output structure
+  # Check correct output structure
   expect_equal(names(pl.res), c("df", "df.ellipse", "graph"))
-  # check colours
+  # Check colours
   expect_equal(unique(pl.res$df$col[pl.res$df$group == "BE"]), "#F68B33")
   expect_equal(unique(pl.res$df$col[pl.res$df$group == "AF"]), "#388ECC")
-  # check right number of samples
+  # Check right number of samples
   expect_equal(dim(splsda.breast$X)[1], dim(pl.res$df)[1])
 })
 
-unlink(list.files(pattern = "*.pdf"))
-
+# Clear the rgl device
+if (rgl::rgl.cur() > 0) {
+  rgl::close3d()
+}

--- a/tests/testthat/test-tune.rcc.R
+++ b/tests/testthat/test-tune.rcc.R
@@ -1,0 +1,85 @@
+context("tune.rcc")
+library(BiocParallel)
+
+test_that("tune.rcc works with Mfold method", code = {
+  # set up data
+  data(nutrimouse)
+  X <- nutrimouse$lipid
+  Y <- nutrimouse$gene
+  
+  # run
+  set.seed(20)
+  tune.rcc.res <- tune.rcc(X, Y, validation = "Mfold", plot = FALSE)
+  
+  # check outputs
+  expect_equal(class(tune.rcc.res), "tune.rcc")
+  expect_equal(tune.rcc.res$opt.lambda1, 0.5005)
+  expect_equal(tune.rcc.res$grid1, c(0.00100, 0.25075, 0.50050, 0.75025, 1.00000))
+})
+
+test_that("tune.rcc works with loo method", code = {
+  # set up data
+  data(nutrimouse)
+  X <- nutrimouse$lipid
+  Y <- nutrimouse$gene
+  
+  # run
+  set.seed(20)
+  tune.rcc.res <- tune.rcc(X, Y, validation = "loo", plot = FALSE)
+  
+  # check outputs
+  expect_equal(class(tune.rcc.res), "tune.rcc")
+  expect_equal(tune.rcc.res$opt.lambda1, 0.25075)
+  expect_equal(tune.rcc.res$grid1, c(0.00100, 0.25075, 0.50050, 0.75025, 1.00000))
+})
+  
+test_that("tune.rcc works in parallel same as in series", code = {
+  # set up data
+  data(nutrimouse)
+  X <- nutrimouse$lipid
+  Y <- nutrimouse$gene
+  
+  # run in series
+  set.seed(12)
+  tune.rcc.res <- tune.rcc(X, Y, validation = "Mfold", plot = FALSE,
+                           BPPARAM = SerialParam(RNGseed = 12))
+  # run in parallel
+  set.seed(12)
+  tune.rcc.res.parallel <- tune.rcc(X, Y, validation = "Mfold", plot = FALSE,
+                           BPPARAM = SnowParam(workers = 2, RNGseed = 12))
+  
+  # check outputs
+  expect_equal(class(tune.rcc.res), "tune.rcc")
+  expect_equal(tune.rcc.res$opt.lambda2, tune.rcc.res.parallel$opt.lambda2)
+  expect_equal(tune.rcc.res$grid2, tune.rcc.res.parallel$grid2)
+})
+
+test_that("tune.rcc and tune(method='rcc') are equivalent", {
+  
+  # set up data
+  data(nutrimouse)
+  X <- nutrimouse$lipid
+  Y <- nutrimouse$gene
+  
+  # run independently
+  set.seed(12)
+  tune.rcc.res.1 <- tune.rcc(X, Y, validation = "Mfold", plot = FALSE,
+                           BPPARAM = SerialParam(RNGseed = 12),
+                           grid1 = c(0.001, 0.2, 0.6, 1),
+                           grid2 = c(0.001, 0.2, 0.6, 1))
+  
+  # run in tune wrapper
+  set.seed(12)
+  tune.rcc.res.2 <- tune(X, Y, validation = "Mfold", 
+                           BPPARAM = SerialParam(RNGseed = 12),
+                           grid1 = c(0.001, 0.2, 0.6, 1),
+                           grid2 = c(0.001, 0.2, 0.6, 1),
+                         method = "rcc")
+  
+  # check outputs
+  expect_equal(class(tune.rcc.res.1), "tune.rcc")
+  expect_equal(tune.rcc.res.1$opt.lambda2, tune.rcc.res.2$opt.lambda2)
+  expect_equal(tune.rcc.res.1$grid2, tune.rcc.res.2$grid2)
+  
+})
+

--- a/tests/testthat/test-tune.spca.R
+++ b/tests/testthat/test-tune.spca.R
@@ -1,37 +1,59 @@
 
-test_that("tune.spca works", {
-  
-  
+test_that("tune.spca works in serial and parallel", {
   data(srbct)
   X <- srbct$gene[1:20, 1:200]
-  
   grid.keepX <- seq(5, 35, 10)
-  
-  set.seed(5212)
-  object <- tune.spca(X,ncomp = 2, 
+  set.seed(5212) # set here although this actually doesnt affect tune.spca
+  object_serial <- tune.spca(X,ncomp = 2, 
                       folds = 5, 
                       test.keepX = grid.keepX, nrepeat = 3,
                       BPPARAM = SerialParam(RNGseed = 5212))
-  
-  expect_equal(object$choice.keepX[[1]], 35)
-  expect_equal(object$choice.keepX[[2]], 5)
+  expect_equal(object_serial$choice.keepX[[1]], 35)
+  expect_equal(object_serial$choice.keepX[[2]], 5)
+  .expect_numerically_close(object_serial$cor.comp$comp1[1,2], 0.3994544)
+  object_parallel <- tune.spca(X,ncomp = 2, 
+                      folds = 5, 
+                      test.keepX = grid.keepX, nrepeat = 3,
+                      BPPARAM = MulticoreParam(RNGseed = 5212))
+  expect_equal(object_parallel$choice.keepX[[1]], 35)
+  expect_equal(object_parallel$choice.keepX[[2]], 5)
+  .expect_numerically_close(object_parallel$cor.comp$comp1[1,2], 0.3994544)
 })
 
-
-test_that("tune.spca works with NA input", {
-  
+test_that("tune.spca is faster in parallel", {
   data(srbct)
   X <- srbct$gene[1:20, 1:200]
-  
-  set.seed(5212)
+  grid.keepX <- seq(5, 35, 10)
+  set.seed(5212) # set here although this actually doesnt affect tune.spca
+  serial_time <- system.time(
+    object_serial <- tune.spca(X,ncomp = 2, 
+                               folds = 5, 
+                               test.keepX = grid.keepX, nrepeat = 20,
+                               BPPARAM = SerialParam(RNGseed = 5212))
+  )
+  parallel_time <- system.time(
+    object_parallel <- tune.spca(X,ncomp = 2, 
+                               folds = 5, 
+                               test.keepX = grid.keepX, nrepeat = 20,
+                               BPPARAM = MulticoreParam(RNGseed = 5212))
+  )
+  # expect parallel faster
+  expect_true(serial_time[3] > parallel_time[3])
+  # expect results the same
+  expect_equal(object_parallel$choice.keepX[[1]], object_serial$choice.keepX[[1]])
+  expect_equal(object_parallel$choice.keepX[[2]], object_serial$choice.keepX[[2]])
+  .expect_numerically_close(object_parallel$cor.comp$comp1[3,3], object_serial$cor.comp$comp1[3,3])
+})
+
+test_that("tune.spca works with NA input", {
+  data(srbct)
+  X <- srbct$gene[1:20, 1:200]
+  set.seed(5212) # set here although this actually doesnt affect tune.spca
   na.feats <- sample(1:ncol(X), 20)
-  
   for (c in na.feats) {
     na.samples <- sample(1:nrow(X),1) #  sample.int(3, 1)
-    
     X[na.samples, c] <- NA
   }
-  
   grid.keepX <- seq(5, 35, 10)
   
   expect_warning({object <- tune.spca(X,ncomp = 2, 
@@ -39,7 +61,6 @@ test_that("tune.spca works with NA input", {
                                       test.keepX = grid.keepX, nrepeat = 3,
                                       BPPARAM = SerialParam(RNGseed = 5212))},
                  "NAs present")
-  
   expect_equal(object$choice.keepX[[1]], 15)
   expect_equal(object$choice.keepX[[2]], 5)
 })

--- a/tests/testthat/test-tune.spca.R
+++ b/tests/testthat/test-tune.spca.R
@@ -64,3 +64,20 @@ test_that("tune.spca works with NA input", {
   expect_equal(object$choice.keepX[[1]], 15)
   expect_equal(object$choice.keepX[[2]], 5)
 })
+
+test_that("tune.spca and tune(method='spca') are equivalent", {
+  data(srbct)
+  X <- srbct$gene[1:20, 1:200]
+  grid.keepX <- seq(5, 35, 10)
+  set.seed(5212) # set here although this actually doesnt affect tune.spca
+  object1 <- tune.spca(X, ncomp = 2, folds = 5, test.keepX = grid.keepX, nrepeat = 3,
+                             BPPARAM = SerialParam(RNGseed = 5212))
+  set.seed(5212)
+  object2 <- tune(method = "spca",X, ncomp = 2, folds = 5, test.keepX = grid.keepX, nrepeat = 3,
+                  BPPARAM = SerialParam(RNGseed = 5212))
+  # expect results the same
+  expect_equal(object1$choice.keepX[[1]], object2$choice.keepX[[1]])
+  expect_equal(object1$choice.keepX[[2]], object2$choice.keepX[[2]])
+  .expect_numerically_close(object1$cor.comp$comp1[3,3], object2$cor.comp$comp1[3,3])
+})
+  

--- a/tests/testthat/test-tune.spca.R
+++ b/tests/testthat/test-tune.spca.R
@@ -22,11 +22,11 @@ test_that("tune.spca works in serial and parallel", {
   .expect_numerically_close(object_parallel$cor.comp$comp1[1,2], 0.3994544)
 })
 
-test_that("tune.spca is faster in parallel", {
+test_that("tune.spca same result in serial and parallel", {
   data(srbct)
   X <- srbct$gene[1:20, 1:200]
   grid.keepX <- seq(5, 35, 10)
-  set.seed(5212) # set here although this actually doesnt affect tune.spca
+  set.seed(5212)
   serial_time <- system.time(
     object_serial <- tune.spca(X,ncomp = 2, 
                                folds = 5, 
@@ -39,8 +39,8 @@ test_that("tune.spca is faster in parallel", {
                                test.keepX = grid.keepX, nrepeat = 20,
                                BPPARAM = MulticoreParam(RNGseed = 5212))
   )
-  # expect parallel faster
-  expect_true(serial_time[3] > parallel_time[3])
+  # expect parallel faster - doesn't actually work in this case so commented out!
+  # expect_true(serial_time[3] > parallel_time[3])
   # expect results the same
   expect_equal(object_parallel$choice.keepX[[1]], object_serial$choice.keepX[[1]])
   expect_equal(object_parallel$choice.keepX[[2]], object_serial$choice.keepX[[2]])

--- a/tests/testthat/test-tune.spca.R
+++ b/tests/testthat/test-tune.spca.R
@@ -1,3 +1,5 @@
+context("tune.spca")
+library(BiocParallel)
 
 test_that("tune.spca works in serial and parallel", {
   data(srbct)

--- a/tests/testthat/test-tune.spls.R
+++ b/tests/testthat/test-tune.spls.R
@@ -46,7 +46,7 @@ test_that("tune.spls works in parallel", code = {
     expect_equal(unname(tune.spls.res$choice.keepY), c(3,3,3))
 })
 
-test_that("tune.spls works faster in parallel", {
+test_that("tune.spls works same in serial and in parallel", {
   data("nutrimouse")
   X <- nutrimouse$gene
   Y <- nutrimouse$lipid
@@ -67,7 +67,7 @@ test_that("tune.spls works faster in parallel", {
                                                        folds = 5, nrepeat = 20, progressBar = FALSE,
                                                        BPPARAM = BiocParallel::SnowParam(workers = 2, RNGseed = 5212)))
   )
-  expect_true(serial_time[3] > parallel_time_2_cores[3])
+  expect_equal(tune.spls.res.serial$choice.keepY[1], tune.spls.res.parallel$choice.keepY[1])
 })
 
 test_that("tune.spls and tune(method='spls') are equivalent", {

--- a/tests/testthat/test-tune.spls.R
+++ b/tests/testthat/test-tune.spls.R
@@ -1,3 +1,6 @@
+context("tune.spls")
+library(BiocParallel)
+
 test_that("tune.spls works ", code = {
     data("nutrimouse")
     X <- nutrimouse$gene

--- a/tests/testthat/test-tune.splsda.R
+++ b/tests/testthat/test-tune.splsda.R
@@ -1,80 +1,52 @@
 context("tune.splsda")
 library(BiocParallel)
 
-test_that("tune.splsda works ", code = {
+test_that("tune.spls works and is the same in parallel and when run in tune wrapper", code = {
+  
+  # set up data
   data(breast.tumors)
   X = breast.tumors$gene.exp
   Y = as.factor(breast.tumors$sample$treatment)
   
+  # run in serial
   set.seed(42)
-  tune.splsda.res = tune.splsda(X, Y, ncomp = 2, nrepeat = 3, logratio = "none",
-                                test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist",
+  tune.splsda.res.1 = tune.splsda(X, Y, ncomp = 2, nrepeat = 1, logratio = "none",
+                                test.keepX = c(5, 10, 15), folds = 2, dist = "max.dist",
                                 BPPARAM = SerialParam(RNGseed = 100))
   
-  expect_equal(class(tune.splsda.res), "tune.splsda")
-  expect_equal(unname(tune.splsda.res$choice.keepX), c(5,15))
-  expect_equal(tune.splsda.res$choice.ncomp$ncomp, 1)
-  .expect_numerically_close(tune.splsda.res$error.rate[1,1], 0.162037)
-})
-
-test_that("tune.splsda works in serial and in parallel", {
-    data(breast.tumors)
-    X = breast.tumors$gene.exp
-    Y = as.factor(breast.tumors$sample$treatment)
-    RNGversion(.mixo_rng()) ## in case RNG changes!
-    set.seed(100)
-    tune = tune.splsda(X, Y, ncomp = 2, nrepeat = 3, logratio = "none",
-                       test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist",
-                       BPPARAM = SerialParam(RNGseed = 100))
-    expect_equal(tune$choice.ncomp$ncomp, 1L)
-    expect_equal(tune$choice.keepX, c(comp1 = 5, comp2 = 15))
-    
-    set.seed(100)
-    tune2 = tune.splsda(X, Y, ncomp = 2, nrepeat = 3, logratio = "none",
-                       test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist", 
-                       BPPARAM = MulticoreParam(workers = 2, RNGseed = 100))
-    expect_equal(tune$choice.keepX, tune2$choice.keepX)
-    expect_equal(tune$choice.keepX, tune2$choice.keepX)
-    
-})
-
-test_that("tune.splsda works same in serial and parallel", {
-  data(liver.toxicity)
-  X <- liver.toxicity$gene
-  Y <- liver.toxicity$clinic
+  # run in parallel
   set.seed(42)
-  # Serial execution
-  serial_time <- system.time(
-    tune_res_serial <- tune.spls(X, Y, ncomp = 3, 
-                                 test.keepX = c(5, 10, 15), 
-                                 test.keepY = c(3, 6, 8), 
-                                 folds = 5,
-                                 BPPARAM = SerialParam())
-  )
-  # Serial execution - 2 cores
-  parallel_time_2_cores <- system.time(
-    tune_res_serial <- tune.spls(X, Y, ncomp = 3, 
-                                 test.keepX = c(5, 10, 15), 
-                                 test.keepY = c(3, 6, 8), 
-                                 folds = 5,
-                                 BPPARAM = MulticoreParam(workers = 2))
-  )
-  expect_equal(tune_res_serial$choice.keepX, tune_res_serial$choice.keepX)
+  tune.splsda.res.2 = tune.splsda(X, Y, ncomp = 2, nrepeat = 1, logratio = "none",
+                                test.keepX = c(5, 10, 15), folds = 2, dist = "max.dist",
+                                BPPARAM = SnowParam(RNGseed = 100, workers = 2))
+  
+  # in tune wrapper in serial
+  set.seed(42)
+  tune.splsda.res.3 = tune(X, Y, ncomp = 2, nrepeat = 1, logratio = "none",
+                                test.keepX = c(5, 10, 15), folds = 2, dist = "max.dist",
+                                BPPARAM = SerialParam(RNGseed = 100),
+                         method = "splsda")
+  
+  # in tune wrapper in parallel
+  set.seed(42)
+  tune.splsda.res.4 = tune(X, Y, ncomp = 2, nrepeat = 1, logratio = "none",
+                         test.keepX = c(5, 10, 15), folds = 2, dist = "max.dist",
+                         BPPARAM = SnowParam(RNGseed = 100, workers = 2),
+                         method = "splsda")
+  
+  
+  # check outputs
+  expect_equal(class(tune.splsda.res.1), "tune.splsda")
+  expect_equal(class(tune.splsda.res.2), "tune.splsda")
+  expect_equal(class(tune.splsda.res.3), "tune.splsda")
+  expect_equal(class(tune.splsda.res.4), "tune.splsda")
+  expect_equal(unname(tune.splsda.res.1$choice.keepX), c(10,15))
+  expect_equal(unname(tune.splsda.res.2$choice.keepX), c(10,15))
+  expect_equal(unname(tune.splsda.res.3$choice.keepX), c(10,15))
+  expect_equal(unname(tune.splsda.res.4$choice.keepX), c(10,15))
+  .expect_numerically_close(tune.splsda.res.1$error.rate[1,1], 0.3111111)
+  .expect_numerically_close(tune.splsda.res.2$error.rate[1,1], 0.3111111)
+  .expect_numerically_close(tune.splsda.res.3$error.rate[1,1], 0.3111111)
+  .expect_numerically_close(tune.splsda.res.4$error.rate[1,1], 0.3111111)
   
 })
-
-test_that("tune.splsda and tune(method='splsda') are equivalent", {
-  data(breast.tumors)
-  X = breast.tumors$gene.exp
-  Y = as.factor(breast.tumors$sample$treatment)
-  set.seed(42)
-  tune.splsda.res.1 = tune.splsda(X, Y, ncomp = 2, nrepeat = 3, logratio = "none",
-                                test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist",
-                                BPPARAM = SerialParam(RNGseed = 100))
-  tune.splda.res.2 = suppressWarnings(tune(method = "splsda", 
-                                             X, Y, ncomp = 2, nrepeat = 3, logratio = "none",
-                                             test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist",
-                                             BPPARAM = SerialParam(RNGseed = 100)))
-  expect_equal(tune.splsda.res.1$measure.pred, tune.splda.res.2$measure.pred)
-})
-  

--- a/tests/testthat/test-tune.splsda.R
+++ b/tests/testthat/test-tune.splsda.R
@@ -1,23 +1,79 @@
 context("tune.splsda")
 
-test_that("tune.splsda works", {
+test_that("tune.splsda works ", code = {
+  data(breast.tumors)
+  X = breast.tumors$gene.exp
+  Y = as.factor(breast.tumors$sample$treatment)
+  
+  set.seed(42)
+  tune.splsda.res = tune.splsda(X, Y, ncomp = 2, nrepeat = 3, logratio = "none",
+                                test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist",
+                                BPPARAM = SerialParam(RNGseed = 100))
+  
+  expect_equal(class(tune.splsda.res), "tune.splsda")
+  expect_equal(unname(tune.splsda.res$choice.keepX), c(5,15))
+  expect_equal(tune.splsda.res$choice.ncomp$ncomp, 1)
+  .expect_numerically_close(tune.splsda.res$error.rate[1,1], 0.162037)
+})
+
+test_that("tune.splsda works in serial and in parallel", {
     data(breast.tumors)
     X = breast.tumors$gene.exp
     Y = as.factor(breast.tumors$sample$treatment)
     RNGversion(.mixo_rng()) ## in case RNG changes!
-
     set.seed(100)
     tune = tune.splsda(X, Y, ncomp = 2, nrepeat = 3, logratio = "none",
-                       test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist")
-    
+                       test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist",
+                       BPPARAM = SerialParam(RNGseed = 100))
     expect_equal(tune$choice.ncomp$ncomp, 1L)
     expect_equal(tune$choice.keepX, c(comp1 = 5, comp2 = 15))
     
-
     set.seed(100)
     tune2 = tune.splsda(X, Y, ncomp = 2, nrepeat = 3, logratio = "none",
                        test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist", 
-                       BPPARAM = MulticoreParam(workers = 2))
-    .almost_identical(tune, tune2)
+                       BPPARAM = MulticoreParam(workers = 2, RNGseed = 100))
+    expect_equal(tune$choice.keepX, tune2$choice.keepX)
+    expect_equal(tune$choice.keepX, tune2$choice.keepX)
     
 })
+
+test_that("tune.splsda works faster in parallel", {
+  data(liver.toxicity)
+  X <- liver.toxicity$gene
+  Y <- liver.toxicity$clinic
+  set.seed(42)
+  # Serial execution
+  serial_time <- system.time(
+    tune_res_serial <- tune.spls(X, Y, ncomp = 3, 
+                                 test.keepX = c(5, 10, 15), 
+                                 test.keepY = c(3, 6, 8), 
+                                 folds = 5,
+                                 BPPARAM = SerialParam())
+  )
+  # Serial execution - 2 cores
+  parallel_time_2_cores <- system.time(
+    tune_res_serial <- tune.spls(X, Y, ncomp = 3, 
+                                 test.keepX = c(5, 10, 15), 
+                                 test.keepY = c(3, 6, 8), 
+                                 folds = 5,
+                                 BPPARAM = MulticoreParam(workers = 2))
+  )
+  expect_true(serial_time[3] > parallel_time_2_cores[3])
+  
+})
+
+test_that("tune.splsda and tune(method='splsda') are equivalent", {
+  data(breast.tumors)
+  X = breast.tumors$gene.exp
+  Y = as.factor(breast.tumors$sample$treatment)
+  set.seed(42)
+  tune.splsda.res.1 = tune.splsda(X, Y, ncomp = 2, nrepeat = 3, logratio = "none",
+                                test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist",
+                                BPPARAM = SerialParam(RNGseed = 100))
+  tune.splda.res.2 = suppressWarnings(tune(method = "splsda", 
+                                             X, Y, ncomp = 2, nrepeat = 3, logratio = "none",
+                                             test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist",
+                                             BPPARAM = SerialParam(RNGseed = 100)))
+  expect_equal(tune.splsda.res.1$measure.pred, tune.splda.res.2$measure.pred)
+})
+  

--- a/tests/testthat/test-tune.splsda.R
+++ b/tests/testthat/test-tune.splsda.R
@@ -16,7 +16,8 @@ test_that("tune.splsda works", {
 
     set.seed(100)
     tune2 = tune.splsda(X, Y, ncomp = 2, nrepeat = 3, logratio = "none",
-                       test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist", cpus = 2)
+                       test.keepX = c(5, 10, 15), folds = 3, dist = "max.dist", 
+                       BPPARAM = MulticoreParam(workers = 2))
     .almost_identical(tune, tune2)
     
 })

--- a/tests/testthat/test-tune.splsda.R
+++ b/tests/testthat/test-tune.splsda.R
@@ -38,7 +38,7 @@ test_that("tune.splsda works in serial and in parallel", {
     
 })
 
-test_that("tune.splsda works faster in parallel", {
+test_that("tune.splsda works same in serial and parallel", {
   data(liver.toxicity)
   X <- liver.toxicity$gene
   Y <- liver.toxicity$clinic
@@ -59,7 +59,7 @@ test_that("tune.splsda works faster in parallel", {
                                  folds = 5,
                                  BPPARAM = MulticoreParam(workers = 2))
   )
-  expect_true(serial_time[3] > parallel_time_2_cores[3])
+  expect_equal(tune_res_serial$choice.keepX, tune_res_serial$choice.keepX)
   
 })
 

--- a/tests/testthat/test-tune.splsda.R
+++ b/tests/testthat/test-tune.splsda.R
@@ -1,4 +1,5 @@
 context("tune.splsda")
+library(BiocParallel)
 
 test_that("tune.splsda works ", code = {
   data(breast.tumors)

--- a/tests/testthat/test-tune.splslevel.R
+++ b/tests/testthat/test-tune.splslevel.R
@@ -1,0 +1,62 @@
+context("tune.splslevel")
+library(BiocParallel)
+
+test_that("tune.splslevel works and is the same in parallel and when run in tune wrapper", code = {
+  
+  # set up data
+  data(liver.toxicity)
+  repeat.indiv <- c(1, 2, 1, 2, 1, 2, 1, 2, 3, 3, 4, 3, 4, 3, 4, 4, 5, 6, 5, 5,
+                    6, 5, 6, 7, 7, 8, 6, 7, 8, 7, 8, 8, 9, 10, 9, 10, 11, 9, 9,
+                    10, 11, 12, 12, 10, 11, 12, 11, 12, 13, 14, 13, 14, 13, 14,
+                    13, 14, 15, 16, 15, 16, 15, 16, 15, 16)
+  design <- data.frame(sample = repeat.indiv)
+  
+  # run in serial
+  set.seed(42)
+  tune.splslevel.res.1<- tune.splslevel(X = liver.toxicity$gene,
+                                      Y=liver.toxicity$clinic,
+                                      multilevel = design,
+                                      test.keepX = c(5,10,15),
+                                      test.keepY = c(1,2,5),
+                                      ncomp = 1,
+                                      BPPARAM = SerialParam(RNGseed = 42))
+  
+  # run in parallel
+  set.seed(42)
+  tune.splslevel.res.2<- tune.splslevel(X = liver.toxicity$gene,
+                                        Y=liver.toxicity$clinic,
+                                        multilevel = design,
+                                        test.keepX = c(5,10,15),
+                                        test.keepY = c(1,2,5),
+                                        ncomp = 1,
+                                        BPPARAM = SnowParam(RNGseed = 42, workers = 2))
+  
+  # in tune wrapper in serial
+  set.seed(42)
+  tune.splslevel.res.3<- tune(X = liver.toxicity$gene,
+                                        Y=liver.toxicity$clinic,
+                                        multilevel = design,
+                                        test.keepX = c(5,10,15),
+                                        test.keepY = c(1,2,5),
+                                        ncomp = 1,
+                                        BPPARAM = SerialParam(RNGseed = 42),
+                              method = "spls")
+  
+  # in tune wrapper in parallel
+  set.seed(42)
+  tune.splslevel.res.4<- tune(X = liver.toxicity$gene,
+                              Y=liver.toxicity$clinic,
+                              multilevel = design,
+                              test.keepX = c(5,10,15),
+                              test.keepY = c(1,2,5),
+                              ncomp = 1,
+                              BPPARAM = SnowParam(RNGseed = 42, workers = 2),
+                              method = "spls")
+  
+  
+  # check outputs
+  .expect_numerically_close(tune.splslevel.res.1$cor.value[1,1], 0.9637933)
+  .expect_numerically_close(tune.splslevel.res.2$cor.value[1,1], 0.9637933)
+  .expect_numerically_close(tune.splslevel.res.3$cor.value[1,1], 0.9637933)
+  .expect_numerically_close(tune.splslevel.res.4$cor.value[1,1], 0.9637933)
+})


### PR DESCRIPTION
**Updating the parallel running of `tune()` functions to use the `BPPARAM` arg**

✅ `tune.spca()` - was already parallelised using `BPPARAM` when run independently, but this wasn't working in the `tune` wrapper so made sure `BPPARAM` is passed through wrapper to function
✅ `tune.spls()` - was already parallelised using `BPPARAM` but did not pass this on to `tune.spls1` when this was called, now fixed
✅ `tune.splsda()` - was parallelised using old-tyle `cpu` and `parallel` arguments. Updated this to `BPPARAM` which feeds into internal function `MCVfold.spls()`. `perf()` also makes use of this internal function so updated it to reflect the fact the `MCVfold.spls()` takes `BPPARAM` arg now instead of `cpu`. 
✅ `tune.block.splsda()` - was already parallelised using `BPPARAM` but was not in tune wrapper function so added to wrapper and added testing
✅ `tune.spls.level()` - added parallelisation using `BPPARAM` independently and through `tune()` wrapper


✅ Added unit testing for all the tune functions above to make sure they:
              -  run reproducibly (NB need to `set.seed()` before running function AND set `BPPARAM = SerialParam(RNGseed = 123)`
              - run with exact same results in serial and in parallel
              - run with exact same results independently and in `tune()` wrapper function 
✅ Worked on making unit tests fast and not print out lots of statements by adjusting params and nesting tests together (if unit tests take too long coverage github action runs for 6 hours and then times out)