### PR TITLE
Issue 334

### DIFF
--- a/R/tune.R
+++ b/R/tune.R
@@ -81,6 +81,9 @@
 #' @param signif.threshold numeric between 0 and 1 indicating the significance
 #' threshold required for improvement in error rate of the components. Default
 #' to 0.01.
+#' @param V Matrix used in the logratio transformation id provided (for tune.pca)
+#' @param plot logical argument indicating whether an image map should be
+#' plotted by calling the \code{imgCV} function. (for tune.rcc)
 #' @param BPPARAM A \linkS4class{BiocParallelParam} object indicating the type
 #'   of parallelisation. See examples.
 #' @param seed set a number here if you want the function to give reproducible outputs. 

--- a/R/tune.R
+++ b/R/tune.R
@@ -368,7 +368,7 @@ tune <-
                                         mode = mode,
                                         ncomp = ncomp, test.keepX = test.keepX, test.keepY = test.keepY,
                                         already.tested.X = already.tested.X, already.tested.Y = already.tested.Y,
-                                        BPPARAM = BPPARAM)
+                                        BPPARAM = BPPARAM, seed = seed)
             }
         }
         

--- a/R/tune.R
+++ b/R/tune.R
@@ -275,7 +275,9 @@ tune <-
                               grid2 = grid2,
                               validation = validation,
                               folds = folds,
-                              plot = plot)
+                              plot = plot,
+                              BPPARAM = BPPARAM,
+                              seed = seed)
             
         } else if (method == "pca") {
             message("Calling 'tune.pca'")

--- a/R/tune.R
+++ b/R/tune.R
@@ -83,6 +83,8 @@
 #' to 0.01.
 #' @param BPPARAM A \linkS4class{BiocParallelParam} object indicating the type
 #'   of parallelisation. See examples.
+#' @param seed set a number here if you want the function to give reproducible outputs. 
+#' Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'. 
 #' @return Depending on the type of analysis performed and the input arguments,
 #' a list that may contain:
 #' 
@@ -346,7 +348,8 @@ tune <-
                                    mode = mode,
                                    measure = measure,
                                    BPPARAM = BPPARAM,
-                                   progressBar = progressBar
+                                   progressBar = progressBar,
+                                   seed = seed
                 )
             } else {
                 message("Calling 'tune.splslevel' with method = 'spls'")

--- a/R/tune.R
+++ b/R/tune.R
@@ -262,7 +262,8 @@ tune <-
                                     design = design,
                                     scheme = scheme,
                                     init = init,
-                                    signif.threshold = signif.threshold
+                                    signif.threshold = signif.threshold,
+                                    seed = seed
                                     )
           
             
@@ -332,7 +333,8 @@ tune <-
                                   nrepeat = nrepeat,
                                   logratio = logratio,
                                   multilevel = multilevel,
-                                  light.output = light.output)
+                                  light.output = light.output,
+                                  seed = seed)
             
         } else if (method == "spls") {
             if(missing(multilevel))

--- a/R/tune.R
+++ b/R/tune.R
@@ -161,61 +161,54 @@
 #' @example ./examples/tune-examples.R
 tune <-
     function (method = c("spls", "splsda", "block.splsda", "mint.splsda", "rcc", "pca", "spca"),
+              # Input data
               X,
               Y,
-              multilevel = NULL,
-              ncomp,
-              study,
-              # mint.splsda, block.splsda
               test.keepX = c(5, 10, 15),
-              # all but pca, rcc, block.splsda
               test.keepY = NULL,
-              # rcc, multilevel
               already.tested.X,
-              # all but pca, rcc
               already.tested.Y,
-              #multilevel
+              # Number of components
+              ncomp,
+              # PLS mode
               mode = c("regression", "canonical", "invariant", "classic"),
-              # multilevel and block.splsda
+              # How to do the cross-validation
               nrepeat = 1,
-              #multilevel, splsda
-              grid1 = seq(0.001, 1, length = 5),
-              # rcc
-              grid2 = seq(0.001, 1, length = 5),
-              # rcc, mint,block.splsda
-              validation = "Mfold",
-              # all but pca
               folds = 10,
-              # all but pca
-              dist = "max.dist",
-              # all but pca, rcc
-              measure = ifelse(method == "spls", "cor", "BER"),
-              # all but pca, rcc
-              auc = FALSE,
-              progressBar = FALSE,
-              # all but pca, rcc
-              near.zero.var = FALSE,
-              # all but pca, rcc
-              logratio = c('none','CLR'),
-              # all but pca, rcc
-              center = TRUE,
-              # pca
-              scale = TRUE,
-              # mint, splsda
+              validation = "Mfold",
               max.iter = 100,
-              #pca
               tol = 1e-09,
-              #pca
-              light.output = TRUE,
-              # all apart from tun.pca
+              signif.threshold = 0.01,
+              # How to transform data
+              logratio = c('none','CLR'),
+              V, 
+              center = TRUE,
+              scale = TRUE,
+              near.zero.var = FALSE,
+              # How to measure accuracy
+              dist = "max.dist",
+              measure = ifelse(method == "spls", "cor", "BER"),
+              # Multilevel
+              multilevel = NULL,
+              # Running params
+              seed = NULL,
               BPPARAM = SerialParam(),
-              # for block.splsda
+              progressBar = FALSE,
+              # Output params
+              auc = FALSE,
+              light.output = TRUE,
+              plot = FALSE,
+              # Multiblock specific params
               indY,
               weighted = TRUE,
               design,
               scheme = "horst",
               init = "svd",
-              signif.threshold = 0.01
+              # CCA specific params
+              grid1 = seq(0.001, 1, length = 5),
+              grid2 = seq(0.001, 1, length = 5),
+              # MINT specific params
+              study
     )
     {
         method = match.arg(method)
@@ -309,7 +302,8 @@ tune <-
                                test.keepX = test.keepX,
                                center = center,
                                scale = scale,
-                               BPPARAM = BPPARAM)
+                               BPPARAM = BPPARAM,
+                               seed = seed)
             
             
         } else if (method == "splsda") {

--- a/R/tune.block.splsda.R
+++ b/R/tune.block.splsda.R
@@ -120,12 +120,15 @@ tune.block.splsda <-
             # if FALSE, output the prediction and classification of each sample during each folds, on each comp, for each repeat
             signif.threshold=0.01,
             BPPARAM = SerialParam(),
+            seed = NULL,
             ...)
   {
     if (hasArg('cpus')) #defunct
     {
     stop("'cpus' has been replaced by BPPARAM. See documentation.")  
     }
+    BPPARAM$RNGseed <- seed
+    set.seed(seed)
     ## ----------- checks -----------
     
     # check input 'Y' and transformation in a dummy matrix

--- a/R/tune.rcc.R
+++ b/R/tune.rcc.R
@@ -67,7 +67,7 @@ tune.rcc <-
              folds = 10,
              plot = TRUE,
              BPPARAM = SerialParam(),
-             seed = seed)
+             seed = NULL)
     {
         
       BPPARAM$RNGseed <- seed

--- a/R/tune.rcc.R
+++ b/R/tune.rcc.R
@@ -37,6 +37,8 @@ library(BiocParallel)
 #' plotted by calling the \code{imgCV} function.
 #' @param BPPARAM a BiocParallel parameter object; see \code{BiocParallel::bpparam} 
 #' for details. Default is \code{MulticoreParam()} for parallel processing.
+#' @param seed set a number here if you want the function to give reproducible outputs. 
+#' Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'. 
 #' @return The returned value is a list with components: \item{opt.lambda1,}{}
 #' \item{opt.lambda2}{value of the parameters of regularization on which the
 #' cross-validation method reached its optimal.} \item{opt.score}{the optimal
@@ -64,9 +66,13 @@ tune.rcc <-
              validation = c("loo", "Mfold"), 
              folds = 10,
              plot = TRUE,
-             BPPARAM = SerialParam())
+             BPPARAM = SerialParam(),
+             seed = seed)
     {
         
+      BPPARAM$RNGseed <- seed
+      set.seed(seed)
+      
         # validation des arguments #
         #--------------------------#
         if (length(dim(X)) != 2 || length(dim(Y)) != 2) 

--- a/R/tune.spca.R
+++ b/R/tune.spca.R
@@ -39,9 +39,11 @@ tune.spca <- function(X,
                       test.keepX, 
                       center = TRUE, 
                       scale = TRUE, 
-                      BPPARAM = SerialParam())
+                      BPPARAM = SerialParam(),
+                      seed = NULL)
 {
     ## evaluate all args
+    BPPARAM$RNGseed <- seed
     mget(names(formals()), sys.frame(sys.nframe()))
     X <- data.matrix(X, rownames.force = TRUE)
     X <- scale(X, center = center, scale = scale)

--- a/R/tune.spca.R
+++ b/R/tune.spca.R
@@ -20,6 +20,8 @@
 #' @param folds Number of folds in 'Mfold' cross-validation. See details.
 #' @param BPPARAM A \linkS4class{BiocParallelParam} object indicating the type
 #'   of parallelisation. See examples.
+#' @param seed set a number here if you want the function to give reproducible outputs. 
+#' Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'. 
 #' @importFrom BiocParallel SerialParam bplapply
 #' @return A \code{tune.spca} object containing: \describe{ 
 #' \item{call}{ The

--- a/R/tune.spls.R
+++ b/R/tune.spls.R
@@ -171,6 +171,7 @@ tune.spls <-
                         progressBar = progressBar,
                         nrepeat = nrepeat,
                         BPPARAM = BPPARAM,
+                        seed = seed,
                         ...
       )
       ## --- call

--- a/R/tune.spls1.R
+++ b/R/tune.spls1.R
@@ -106,6 +106,8 @@
 #' @param light.output if set to FALSE, the prediction/classification of each
 #' sample for each of \code{test.keepX} and each comp is returned.
 #' @template arg/BPPARAM
+#' @param seed set a number here if you want the function to give reproducible outputs. 
+#' Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'. 
 #' @return A list that contains: \item{error.rate}{returns the prediction error
 #' for each \code{test.keepX} on each component, averaged across all repeats
 #' and subsampling folds. Standard deviation is also output. All error rates
@@ -184,12 +186,16 @@ tune.spls1 <- #TODO naming for tune.spls1 is wrong. it should hint the block whe
               nrepeat = 1,
               multilevel = NULL,
               light.output = TRUE,
-              BPPARAM = SerialParam()
+              BPPARAM = SerialParam(),
+              seed = NULL
     )
     {    #-- checking general input parameters --------------------------------------#
         #---------------------------------------------------------------------------#
         
         #------------------#
+      BPPARAM$RNGseed <- seed
+      set.seed(seed)
+      
         if(!is(X, "matrix"))
             X= as.matrix(X)
         

--- a/R/tune.splsda.R
+++ b/R/tune.splsda.R
@@ -110,6 +110,8 @@
 #' threshold required for improvement in error rate of the components. Default
 #' to 0.01.
 #' @template arg/BPPARAM
+#' @param seed set a number here if you want the function to give reproducible outputs. 
+#' Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'. 
 #' @return Depending on the type of analysis performed, a list that contains:
 #' \item{error.rate}{returns the prediction error for each \code{test.keepX} on
 #' each component, averaged across all repeats and subsampling folds. Standard
@@ -199,11 +201,15 @@ tune.splsda <-
               multilevel = NULL,
               light.output = TRUE,
               signif.threshold = 0.01, 
-              BPPARAM = SerialParam()
+              BPPARAM = SerialParam(),
+              seed = NULL
     )
     {    #-- checking general input parameters --------------------------------------#
         #---------------------------------------------------------------------------#
         
+      BPPARAM$RNGseed <- seed
+      set.seed(seed)
+      
         #-- check significance threshold
         signif.threshold <- .check_alpha(signif.threshold)
         

--- a/R/tune.splslevel.R
+++ b/R/tune.splslevel.R
@@ -24,6 +24,8 @@
 #' indicating the number of variables to select from the \eqn{Y} data set on
 #' the firsts components.
 #' @param BPPARAM BiocParallelParam object to manage parallelization
+#' @param seed set a number here if you want the function to give reproducible outputs. 
+#' Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'. 
 #' @return
 #' \item{cor.value}{correlation between latent variables}
 #' @export
@@ -35,7 +37,11 @@ tune.splslevel <- function (X, Y,
                             test.keepY = rep(ncol(Y), ncomp),
                             already.tested.X = NULL,
                             already.tested.Y = NULL,
-                            BPPARAM = BiocParallel::SerialParam()) {
+                            BPPARAM = BiocParallel::SerialParam(),
+                            seed = seed) {
+  
+  BPPARAM$RNGseed <- seed
+  set.seed(seed)
 
     message("For a multilevel spls analysis, the tuning criterion is based on the maximisation of the correlation between the components from both data sets")
     

--- a/examples/tune.spca-examples.R
+++ b/examples/tune.spca-examples.R
@@ -1,12 +1,12 @@
 data("nutrimouse")
-set.seed(42)
 nrepeat <- 5
 tune.spca.res <- tune.spca(
     X = nutrimouse$lipid,
     ncomp = 2,
     nrepeat = nrepeat,
     folds = 3,
-    test.keepX = seq(5, 15, 5)
+    test.keepX = seq(5, 15, 5),
+    seed = 42
 )
 tune.spca.res
 plot(tune.spca.res)

--- a/man/tune.Rd
+++ b/man/tune.Rd
@@ -119,6 +119,9 @@ classification error rate, should be a subset of \code{"centroids.dist"},
 measurements) that indicates the repeated measures on each individual, i.e.
 the individuals ID. See Details.}
 
+\item{seed}{set a number here if you want the function to give reproducible outputs. 
+Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'.}
+
 \item{BPPARAM}{A \linkS4class{BiocParallelParam} object indicating the type
 of parallelisation. See examples.}
 

--- a/man/tune.Rd
+++ b/man/tune.Rd
@@ -93,6 +93,8 @@ to 0.01.}
 
 \item{logratio}{one of ('none','CLR'). Default to 'none'}
 
+\item{V}{Matrix used in the logratio transformation id provided (for tune.pca)}
+
 \item{center}{a logical value indicating whether the variables should be
 shifted to be zero centered. Alternately, a vector of length equal the
 number of columns of \code{X} can be supplied. The value is passed to
@@ -133,6 +135,9 @@ performance of the model.}
 
 \item{light.output}{if set to FALSE, the prediction/classification of each
 sample for each of \code{test.keepX} and each comp is returned.}
+
+\item{plot}{logical argument indicating whether an image map should be
+plotted by calling the \code{imgCV} function. (for tune.rcc)}
 
 \item{indY}{To supply if \code{Y} is missing, indicates the position of 
 the matrix response in the list \code{X}.}

--- a/man/tune.Rd
+++ b/man/tune.Rd
@@ -8,37 +8,40 @@ tune(
   method = c("spls", "splsda", "block.splsda", "mint.splsda", "rcc", "pca", "spca"),
   X,
   Y,
-  multilevel = NULL,
-  ncomp,
-  study,
   test.keepX = c(5, 10, 15),
   test.keepY = NULL,
   already.tested.X,
   already.tested.Y,
+  ncomp,
   mode = c("regression", "canonical", "invariant", "classic"),
   nrepeat = 1,
-  grid1 = seq(0.001, 1, length = 5),
-  grid2 = seq(0.001, 1, length = 5),
-  validation = "Mfold",
   folds = 10,
-  dist = "max.dist",
-  measure = ifelse(method == "spls", "cor", "BER"),
-  auc = FALSE,
-  progressBar = FALSE,
-  near.zero.var = FALSE,
-  logratio = c("none", "CLR"),
-  center = TRUE,
-  scale = TRUE,
+  validation = "Mfold",
   max.iter = 100,
   tol = 1e-09,
-  light.output = TRUE,
+  signif.threshold = 0.01,
+  logratio = c("none", "CLR"),
+  V,
+  center = TRUE,
+  scale = TRUE,
+  near.zero.var = FALSE,
+  dist = "max.dist",
+  measure = ifelse(method == "spls", "cor", "BER"),
+  multilevel = NULL,
+  seed = NULL,
   BPPARAM = SerialParam(),
+  progressBar = FALSE,
+  auc = FALSE,
+  light.output = TRUE,
+  plot = FALSE,
   indY,
   weighted = TRUE,
   design,
   scheme = "horst",
   init = "svd",
-  signif.threshold = 0.01
+  grid1 = seq(0.001, 1, length = 5),
+  grid2 = seq(0.001, 1, length = 5),
+  study
 )
 }
 \arguments{
@@ -51,15 +54,6 @@ suitable function. \code{method} has to be one of the following: "spls",
 \item{Y}{Either a factor or a class vector for the discrete outcome, or a
 numeric vector or matrix of continuous responses (for multi-response
 models).}
-
-\item{multilevel}{Design matrix for multilevel analysis (for repeated
-measurements) that indicates the repeated measures on each individual, i.e.
-the individuals ID. See Details.}
-
-\item{ncomp}{the number of components to include in the model.}
-
-\item{study}{grouping factor indicating which samples are from the same
-study}
 
 \item{test.keepX}{numeric vector for the different number of variables to
 test from the \eqn{X} data set}
@@ -75,37 +69,27 @@ the firsts components.}
 numeric vector indicating the number of variables to select from the \eqn{Y}
 data set on the first components}
 
+\item{ncomp}{the number of components to include in the model.}
+
 \item{mode}{character string. What type of algorithm to use, (partially)
 matching one of \code{"regression"}, \code{"canonical"}, \code{"invariant"}
 or \code{"classic"}. See Details.}
 
 \item{nrepeat}{Number of times the Cross-Validation process is repeated.}
 
-\item{grid1, grid2}{vector numeric defining the values of \code{lambda1} and
-\code{lambda2} at which cross-validation score should be computed. Defaults
-to \code{grid1=grid2=seq(0.001, 1, length=5)}.}
+\item{folds}{the folds in the Mfold cross-validation. See Details.}
 
 \item{validation}{character.  What kind of (internal) validation to use,
 matching one of \code{"Mfold"} or \code{"loo"} (see below). Default is
 \code{"Mfold"}.}
 
-\item{folds}{the folds in the Mfold cross-validation. See Details.}
+\item{max.iter}{Integer, the maximum number of iterations.}
 
-\item{dist}{distance metric to estimate the
-classification error rate, should be a subset of \code{"centroids.dist"},
-\code{"mahalanobis.dist"} or \code{"max.dist"} (see Details).}
+\item{tol}{Numeric, convergence tolerance criteria.}
 
-\item{measure}{The tuning measure used for different methods. See details.}
-
-\item{auc}{if \code{TRUE} calculate the Area Under the Curve (AUC)
-performance of the model.}
-
-\item{progressBar}{by default set to \code{TRUE} to output the progress bar
-of the computation.}
-
-\item{near.zero.var}{Logical, see the internal \code{\link{nearZeroVar}}
-function (should be set to TRUE in particular for data with many zero
-values). Default value is FALSE}
+\item{signif.threshold}{numeric between 0 and 1 indicating the significance
+threshold required for improvement in error rate of the components. Default
+to 0.01.}
 
 \item{logratio}{one of ('none','CLR'). Default to 'none'}
 
@@ -121,15 +105,31 @@ scaling is advisable. Alternatively, a vector of length equal the number of
 columns of \code{X} can be supplied. The value is passed to
 \code{\link{scale}}.}
 
-\item{max.iter}{Integer, the maximum number of iterations.}
+\item{near.zero.var}{Logical, see the internal \code{\link{nearZeroVar}}
+function (should be set to TRUE in particular for data with many zero
+values). Default value is FALSE}
 
-\item{tol}{Numeric, convergence tolerance criteria.}
+\item{dist}{distance metric to estimate the
+classification error rate, should be a subset of \code{"centroids.dist"},
+\code{"mahalanobis.dist"} or \code{"max.dist"} (see Details).}
 
-\item{light.output}{if set to FALSE, the prediction/classification of each
-sample for each of \code{test.keepX} and each comp is returned.}
+\item{measure}{The tuning measure used for different methods. See details.}
+
+\item{multilevel}{Design matrix for multilevel analysis (for repeated
+measurements) that indicates the repeated measures on each individual, i.e.
+the individuals ID. See Details.}
 
 \item{BPPARAM}{A \linkS4class{BiocParallelParam} object indicating the type
 of parallelisation. See examples.}
+
+\item{progressBar}{by default set to \code{TRUE} to output the progress bar
+of the computation.}
+
+\item{auc}{if \code{TRUE} calculate the Area Under the Curve (AUC)
+performance of the model.}
+
+\item{light.output}{if set to FALSE, the prediction/classification of each
+sample for each of \code{test.keepX} and each comp is returned.}
 
 \item{indY}{To supply if \code{Y} is missing, indicates the position of 
 the matrix response in the list \code{X}.}
@@ -154,9 +154,12 @@ off-diagonal elements of a fully connected design (see examples in
 Value Decomposition of the product of each block of X with Y ('svd') or each
 block independently ('svd.single'). Default = \code{svd.single}}
 
-\item{signif.threshold}{numeric between 0 and 1 indicating the significance
-threshold required for improvement in error rate of the components. Default
-to 0.01.}
+\item{grid1, grid2}{vector numeric defining the values of \code{lambda1} and
+\code{lambda2} at which cross-validation score should be computed. Defaults
+to \code{grid1=grid2=seq(0.001, 1, length=5)}.}
+
+\item{study}{grouping factor indicating which samples are from the same
+study}
 }
 \value{
 Depending on the type of analysis performed and the input arguments,

--- a/man/tune.block.splsda.Rd
+++ b/man/tune.block.splsda.Rd
@@ -29,6 +29,7 @@ tune.block.splsda(
   light.output = TRUE,
   signif.threshold = 0.01,
   BPPARAM = SerialParam(),
+  seed = NULL,
   ...
 )
 }
@@ -114,6 +115,9 @@ to 0.01.}
 
 \item{BPPARAM}{A \linkS4class{BiocParallelParam} object indicating the type
 of parallelisation. See examples.}
+
+\item{seed}{set a number here if you want the function to give reproducible outputs. 
+Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'.}
 
 \item{...}{Optional arguments:
 \itemize{

--- a/man/tune.rcc.Rd
+++ b/man/tune.rcc.Rd
@@ -13,7 +13,7 @@ tune.rcc(
   folds = 10,
   plot = TRUE,
   BPPARAM = SerialParam(),
-  seed = seed
+  seed = NULL
 )
 }
 \arguments{

--- a/man/tune.rcc.Rd
+++ b/man/tune.rcc.Rd
@@ -12,7 +12,8 @@ tune.rcc(
   validation = c("loo", "Mfold"),
   folds = 10,
   plot = TRUE,
-  BPPARAM = SerialParam()
+  BPPARAM = SerialParam(),
+  seed = seed
 )
 }
 \arguments{
@@ -38,6 +39,9 @@ plotted by calling the \code{imgCV} function.}
 
 \item{BPPARAM}{a BiocParallel parameter object; see \code{BiocParallel::bpparam} 
 for details. Default is \code{MulticoreParam()} for parallel processing.}
+
+\item{seed}{set a number here if you want the function to give reproducible outputs. 
+Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'.}
 }
 \value{
 The returned value is a list with components: \item{opt.lambda1,}{}

--- a/man/tune.spca.Rd
+++ b/man/tune.spca.Rd
@@ -79,14 +79,14 @@ achieved by setting \code{folds = nrow(X)}.
 }
 \examples{
 data("nutrimouse")
-set.seed(42)
 nrepeat <- 5
 tune.spca.res <- tune.spca(
     X = nutrimouse$lipid,
     ncomp = 2,
     nrepeat = nrepeat,
     folds = 3,
-    test.keepX = seq(5, 15, 5)
+    test.keepX = seq(5, 15, 5),
+    seed = 42
 )
 tune.spca.res
 plot(tune.spca.res)

--- a/man/tune.spca.Rd
+++ b/man/tune.spca.Rd
@@ -12,7 +12,8 @@ tune.spca(
   test.keepX,
   center = TRUE,
   scale = TRUE,
-  BPPARAM = SerialParam()
+  BPPARAM = SerialParam(),
+  seed = NULL
 )
 }
 \arguments{

--- a/man/tune.spca.Rd
+++ b/man/tune.spca.Rd
@@ -45,6 +45,9 @@ scaled to have unit variance before the analysis takes place.}
 
 \item{BPPARAM}{A \linkS4class{BiocParallelParam} object indicating the type
 of parallelisation. See examples.}
+
+\item{seed}{set a number here if you want the function to give reproducible outputs. 
+Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'.}
 }
 \value{
 A \code{tune.spca} object containing: \describe{ 

--- a/man/tune.splsda.Rd
+++ b/man/tune.splsda.Rd
@@ -25,7 +25,8 @@ tune.splsda(
   multilevel = NULL,
   light.output = TRUE,
   signif.threshold = 0.01,
-  BPPARAM = SerialParam()
+  BPPARAM = SerialParam(),
+  seed = NULL
 )
 }
 \arguments{
@@ -91,6 +92,9 @@ to 0.01.}
 
 \item{BPPARAM}{A \linkS4class{BiocParallelParam} object indicating the type
 of parallelisation. See examples in \code{?tune.spca}.}
+
+\item{seed}{set a number here if you want the function to give reproducible outputs. 
+Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'.}
 }
 \value{
 Depending on the type of analysis performed, a list that contains:

--- a/man/tune.splslevel.Rd
+++ b/man/tune.splslevel.Rd
@@ -14,7 +14,8 @@ tune.splslevel(
   test.keepY = rep(ncol(Y), ncomp),
   already.tested.X = NULL,
   already.tested.Y = NULL,
-  BPPARAM = BiocParallel::SerialParam()
+  BPPARAM = BiocParallel::SerialParam(),
+  seed = seed
 )
 }
 \arguments{
@@ -48,6 +49,9 @@ indicating the number of variables to select from the \eqn{Y} data set on
 the firsts components.}
 
 \item{BPPARAM}{BiocParallelParam object to manage parallelization}
+
+\item{seed}{set a number here if you want the function to give reproducible outputs. 
+Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'.}
 }
 \value{
 \item{cor.value}{correlation between latent variables}

--- a/tests/testthat/test-tune.block.splsda.R
+++ b/tests/testthat/test-tune.block.splsda.R
@@ -26,7 +26,6 @@ test_that("tune.block.splsda works with and without parallel without auc", {
     Y <- breast.TCGA$data.train$subtype[subset]
     
     ## -------------------- 1 cpu 
-    set.seed(42)
     tune11 = tune.block.splsda(
         X = data,
         Y = Y,
@@ -35,12 +34,11 @@ test_that("tune.block.splsda works with and without parallel without auc", {
         test.keepX = test.keepX,
         design = design,
         nrepeat = nrep,
-        BPPARAM = SerialParam(RNGseed = 42)
+        BPPARAM = SerialParam(), seed = 42
     )
     expect_is(tune11, "tune.block.splsda")
     
     ## -------------------- parallel
-    set.seed(42)
     tune41 = tune.block.splsda(
         X = data,
         Y = Y,
@@ -49,7 +47,7 @@ test_that("tune.block.splsda works with and without parallel without auc", {
         test.keepX = test.keepX,
         design = design,
         nrepeat = nrep,
-        BPPARAM = SnowParam(workers = 2, RNGseed = 42)
+        BPPARAM = SnowParam(workers = 2), seed = 42
     )
     expect_equal(tune11$choice.keepX, tune41$choice.keepX)
     
@@ -141,7 +139,7 @@ test_that("tune.block.splsda works independently and in tune wrapper the same", 
     test.keepX = test.keepX,
     design = design,
     nrepeat = nrep,
-    BPPARAM = SerialParam(RNGseed = 42)
+    BPPARAM = SerialParam(), seed = 42
   )
   expect_is(tune11, "tune.block.splsda")
   
@@ -156,7 +154,7 @@ test_that("tune.block.splsda works independently and in tune wrapper the same", 
     test.keepX = test.keepX,
     design = design,
     nrepeat = nrep,
-    BPPARAM = SerialParam(RNGseed = 42)
+    BPPARAM = SerialParam(), seed = 42
   )
   expect_equal(tune11$choice.keepX, tune41$choice.keepX)
 })

--- a/tests/testthat/test-tune.rcc.R
+++ b/tests/testthat/test-tune.rcc.R
@@ -8,8 +8,7 @@ test_that("tune.rcc works with Mfold method", code = {
   Y <- nutrimouse$gene
   
   # run
-  set.seed(20)
-  tune.rcc.res <- tune.rcc(X, Y, validation = "Mfold", plot = FALSE)
+  tune.rcc.res <- tune.rcc(X, Y, validation = "Mfold", plot = FALSE, seed = 20)
   
   # check outputs
   expect_equal(class(tune.rcc.res), "tune.rcc")
@@ -24,8 +23,7 @@ test_that("tune.rcc works with loo method", code = {
   Y <- nutrimouse$gene
   
   # run
-  set.seed(20)
-  tune.rcc.res <- tune.rcc(X, Y, validation = "loo", plot = FALSE)
+  tune.rcc.res <- tune.rcc(X, Y, validation = "loo", plot = FALSE, seed = 20)
   
   # check outputs
   expect_equal(class(tune.rcc.res), "tune.rcc")
@@ -40,13 +38,11 @@ test_that("tune.rcc works in parallel same as in series", code = {
   Y <- nutrimouse$gene
   
   # run in series
-  set.seed(12)
   tune.rcc.res <- tune.rcc(X, Y, validation = "Mfold", plot = FALSE,
-                           BPPARAM = SerialParam(RNGseed = 12))
+                           BPPARAM = SerialParam(RNGseed = NULL), seed = 12)
   # run in parallel
-  set.seed(12)
   tune.rcc.res.parallel <- tune.rcc(X, Y, validation = "Mfold", plot = FALSE,
-                           BPPARAM = SnowParam(workers = 2, RNGseed = 12))
+                           BPPARAM = SnowParam(workers = 2, RNGseed = NULL), seed = 12)
   
   # check outputs
   expect_equal(class(tune.rcc.res), "tune.rcc")
@@ -62,16 +58,14 @@ test_that("tune.rcc and tune(method='rcc') are equivalent", {
   Y <- nutrimouse$gene
   
   # run independently
-  set.seed(12)
   tune.rcc.res.1 <- tune.rcc(X, Y, validation = "Mfold", plot = FALSE,
-                           BPPARAM = SerialParam(RNGseed = 12),
+                           BPPARAM = SerialParam(RNGseed = NULL), seed = 12,
                            grid1 = c(0.001, 0.2, 0.6, 1),
                            grid2 = c(0.001, 0.2, 0.6, 1))
   
   # run in tune wrapper
-  set.seed(12)
   tune.rcc.res.2 <- tune(X, Y, validation = "Mfold", 
-                           BPPARAM = SerialParam(RNGseed = 12),
+                           BPPARAM = SerialParam(), seed = 12,
                            grid1 = c(0.001, 0.2, 0.6, 1),
                            grid2 = c(0.001, 0.2, 0.6, 1),
                          method = "rcc")

--- a/tests/testthat/test-tune.spca.R
+++ b/tests/testthat/test-tune.spca.R
@@ -5,18 +5,17 @@ test_that("tune.spca works in serial and parallel", {
   data(srbct)
   X <- srbct$gene[1:20, 1:200]
   grid.keepX <- seq(5, 35, 10)
-  set.seed(5212) # set here although this actually doesnt affect tune.spca
   object_serial <- tune.spca(X,ncomp = 2, 
                       folds = 5, 
                       test.keepX = grid.keepX, nrepeat = 3,
-                      BPPARAM = SerialParam(RNGseed = 5212))
+                      BPPARAM = SerialParam(RNGseed = NULL), seed = 5212)
   expect_equal(object_serial$choice.keepX[[1]], 35)
   expect_equal(object_serial$choice.keepX[[2]], 5)
   .expect_numerically_close(object_serial$cor.comp$comp1[1,2], 0.3994544)
   object_parallel <- tune.spca(X,ncomp = 2, 
                       folds = 5, 
                       test.keepX = grid.keepX, nrepeat = 3,
-                      BPPARAM = MulticoreParam(RNGseed = 5212))
+                      BPPARAM = MulticoreParam(), seed = 5212)
   expect_equal(object_parallel$choice.keepX[[1]], 35)
   expect_equal(object_parallel$choice.keepX[[2]], 5)
   .expect_numerically_close(object_parallel$cor.comp$comp1[1,2], 0.3994544)
@@ -26,18 +25,17 @@ test_that("tune.spca same result in serial and parallel", {
   data(srbct)
   X <- srbct$gene[1:20, 1:200]
   grid.keepX <- seq(5, 35, 10)
-  set.seed(5212)
   serial_time <- system.time(
     object_serial <- tune.spca(X,ncomp = 2, 
                                folds = 5, 
                                test.keepX = grid.keepX, nrepeat = 20,
-                               BPPARAM = SerialParam(RNGseed = 5212))
+                               BPPARAM = SerialParam(RNGseed = 10000), seed = 5212) # RNGseed in BPPARAM ignored
   )
   parallel_time <- system.time(
     object_parallel <- tune.spca(X,ncomp = 2, 
                                folds = 5, 
                                test.keepX = grid.keepX, nrepeat = 20,
-                               BPPARAM = MulticoreParam(RNGseed = 5212))
+                               BPPARAM = MulticoreParam(), seed = 5212)
   )
   # expect parallel faster - doesn't actually work in this case so commented out!
   # expect_true(serial_time[3] > parallel_time[3])
@@ -61,7 +59,7 @@ test_that("tune.spca works with NA input", {
   expect_warning({object <- tune.spca(X,ncomp = 2, 
                                       folds = 5, 
                                       test.keepX = grid.keepX, nrepeat = 3,
-                                      BPPARAM = SerialParam(RNGseed = 5212))},
+                                      BPPARAM = SerialParam(), seed = 5212)},
                  "NAs present")
   expect_equal(object$choice.keepX[[1]], 15)
   expect_equal(object$choice.keepX[[2]], 5)
@@ -71,12 +69,10 @@ test_that("tune.spca and tune(method='spca') are equivalent", {
   data(srbct)
   X <- srbct$gene[1:20, 1:200]
   grid.keepX <- seq(5, 35, 10)
-  set.seed(5212) # set here although this actually doesnt affect tune.spca
   object1 <- tune.spca(X, ncomp = 2, folds = 5, test.keepX = grid.keepX, nrepeat = 3,
-                             BPPARAM = SerialParam(RNGseed = 5212))
-  set.seed(5212)
+                             BPPARAM = SerialParam(), seed = 5212)
   object2 <- tune(method = "spca",X, ncomp = 2, folds = 5, test.keepX = grid.keepX, nrepeat = 3,
-                  BPPARAM = SerialParam(RNGseed = 5212))
+                  BPPARAM = SerialParam(), seed = 5212)
   # expect results the same
   expect_equal(object1$choice.keepX[[1]], object2$choice.keepX[[1]])
   expect_equal(object1$choice.keepX[[2]], object2$choice.keepX[[2]])

--- a/tests/testthat/test-tune.spls.R
+++ b/tests/testthat/test-tune.spls.R
@@ -9,7 +9,6 @@ test_that("tune.spls works and is the same in parallel and when run in tune wrap
   Y <- nutrimouse$lipid
   
   # run in serial
-  # set.seed(42)
   tune.spls.res.1 = suppressWarnings(tune.spls(X, Y, ncomp = 2,
                                              test.keepX = seq(5, 10, 5),
                                              test.keepY = seq(3, 6, 3), measure = "cor",
@@ -18,7 +17,6 @@ test_that("tune.spls works and is the same in parallel and when run in tune wrap
                                              seed = 5212))
   
   # run in parallel
-  # set.seed(42)
   tune.spls.res.2 = suppressWarnings(tune.spls(X, Y, ncomp = 2,
                                                test.keepX = seq(5, 10, 5),
                                                test.keepY = seq(3, 6, 3), measure = "cor",
@@ -26,40 +24,42 @@ test_that("tune.spls works and is the same in parallel and when run in tune wrap
                                                BPPARAM = SnowParam(workers = 2),
                                                seed = 5212))
   
-  # # in tune wrapper in serial
-  # set.seed(42)
-  # tune.spls.res.3 = suppressWarnings(tune(X, Y, ncomp = 2,
-  #                                              test.keepX = seq(5, 10, 5),
-  #                                              test.keepY = seq(3, 6, 3), measure = "cor",
-  #                                              folds = 2, nrepeat = 1, progressBar = FALSE,
-  #                                              BPPARAM = SerialParam(RNGseed = 5212),
-  #                                         method = "spls"),
-  #                                    )
-  # 
-  # # in tune wrapper in parallel
-  # set.seed(42)
-  # tune.spls.res.4 = suppressWarnings(tune(X, Y, ncomp = 2,
-  #                                         test.keepX = seq(5, 10, 5),
-  #                                         test.keepY = seq(3, 6, 3), measure = "cor",
-  #                                         folds = 2, nrepeat = 1, progressBar = FALSE,
-  #                                         BPPARAM = SnowParam(RNGseed = 5212, workers = 2),
-  #                                         method = "spls"),
-  # )
+  # in tune wrapper in serial
+  tune.spls.res.3 = suppressWarnings(tune(X, Y, ncomp = 2,
+                                               test.keepX = seq(5, 10, 5),
+                                               test.keepY = seq(3, 6, 3), measure = "cor",
+                                               folds = 2, nrepeat = 1, progressBar = FALSE,
+                                               BPPARAM = SerialParam(RNGseed = NULL),
+                                          seed = 5212,
+                                          method = "spls"),
+                                     )
+
+  # in tune wrapper in parallel
+  tune.spls.res.4 = suppressWarnings(tune(X, Y, ncomp = 2,
+                                          test.keepX = seq(5, 10, 5),
+                                          test.keepY = seq(3, 6, 3), measure = "cor",
+                                          folds = 2, nrepeat = 1, progressBar = FALSE,
+                                          BPPARAM = SnowParam(workers = 2),
+                                          method = "spls",
+                                          seed = 5212),
+  )
   
   
   # check outputs
   expect_equal(class(tune.spls.res.1), class(tune.spls.res.2), class(tune.spls.res.3), class(tune.spls.res.4), "tune.spls")
   expect_equal(unname(tune.spls.res.1$choice.keepX), c(10,5))
   expect_equal(unname(tune.spls.res.2$choice.keepX), c(10,5))
-  # expect_equal(unname(tune.spls.res.3$choice.keepX), c(10,10))
-  # expect_equal(unname(tune.spls.res.4$choice.keepX), c(10,19))
+  expect_equal(unname(tune.spls.res.3$choice.keepX), c(10,5))
+  expect_equal(unname(tune.spls.res.4$choice.keepX), c(10,5))
   expect_equal(unname(tune.spls.res.1$choice.keepY), c(3,6))
   expect_equal(unname(tune.spls.res.2$choice.keepY), c(3,6))
-  # expect_equal(unname(tune.spls.res.3$choice.keepY), c(3,3))
-  # expect_equal(unname(tune.spls.res.4$choice.keepY), c(3,3))
+  expect_equal(unname(tune.spls.res.3$choice.keepY), c(3,6))
+  expect_equal(unname(tune.spls.res.4$choice.keepY), c(3,6))
   
   # check outputs exactly the same regardless of how the function was run
   expect_equal(tune.spls.res.1$measure.pred$mean, tune.spls.res.2$measure.pred$mean)
+  expect_equal(tune.spls.res.1$measure.pred$mean, tune.spls.res.3$measure.pred$mean)
+  expect_equal(tune.spls.res.1$measure.pred$mean, tune.spls.res.4$measure.pred$mean)
 })
 
 ## If ncol(Y) == 1 tune.spls calls tune.spls1
@@ -76,34 +76,30 @@ test_that("tune.spls.1 works and is the same in parallel and when run in tune wr
   list.keepX <- c(5:10, seq(15, 50, 5))     
   
   # run in serial
-  set.seed(33)
   tune.spls1.MAE.1 <- tune.spls(X, y, ncomp = 2, test.keepX = list.keepX, 
                                 validation = 'Mfold', folds = 2, nrepeat = 1, 
                                 progressBar = FALSE, measure = 'MAE',
-                                BPPARAM = SerialParam(RNGseed = 33))
+                                BPPARAM = SerialParam(RNGseed = NULL), seed = 33)
   
   # run in parallel
-  set.seed(33)
   tune.spls1.MAE.2 <- tune.spls(X, y, ncomp = 2, test.keepX = list.keepX, 
                            validation = 'Mfold', folds = 2, nrepeat = 1, 
                            progressBar = FALSE, measure = 'MAE',
-                           BPPARAM = SnowParam(RNGseed = 33, workers = 2))
+                           BPPARAM = SnowParam(workers = 2), seed = 33)
   
   # in tune wrapper in serial
-  set.seed(33)
   tune.spls1.MAE.3 <- tune(X, y, ncomp = 2, test.keepX = list.keepX, 
                            validation = 'Mfold', folds = 2, nrepeat = 1, 
                            progressBar = FALSE, measure = 'MAE',
-                           BPPARAM = SerialParam(RNGseed = 33),
-                           method = "spls")
+                           BPPARAM = SerialParam(),
+                           method = "spls", seed = 33)
   
   # in tune wrapper in parallel
-  set.seed(33)
   tune.spls1.MAE.4 <- tune(X, y, ncomp = 2, test.keepX = list.keepX, 
                            validation = 'Mfold', folds = 2, nrepeat = 1, 
                            progressBar = FALSE, measure = 'MAE',
-                           BPPARAM = SnowParam(RNGseed = 33, workers = 2),
-                           method = "spls")
+                           BPPARAM = SnowParam(workers = 2),
+                           method = "spls", seed = 33)
   
   
   # check outputs
@@ -112,4 +108,9 @@ test_that("tune.spls.1 works and is the same in parallel and when run in tune wr
   expect_equal(unname(tune.spls1.MAE.2$choice.keepX), c(25, 20))
   expect_equal(unname(tune.spls1.MAE.3$choice.keepX), c(25, 20))
   expect_equal(unname(tune.spls1.MAE.4$choice.keepX), c(25, 20))
+  
+  # check outputs exactly the same regardless of how the function was run
+  expect_equal(tune.spls1.MAE.1$measure.pred$mean, tune.spls1.MAE.2$measure.pred$mean)
+  expect_equal(tune.spls1.MAE.1$measure.pred$mean, tune.spls1.MAE.3$measure.pred$mean)
+  expect_equal(tune.spls1.MAE.1$measure.pred$mean, tune.spls1.MAE.4$measure.pred$mean)
 })

--- a/tests/testthat/test-tune.splsda.R
+++ b/tests/testthat/test-tune.splsda.R
@@ -9,29 +9,25 @@ test_that("tune.spls works and is the same in parallel and when run in tune wrap
   Y = as.factor(breast.tumors$sample$treatment)
   
   # run in serial
-  set.seed(42)
   tune.splsda.res.1 = tune.splsda(X, Y, ncomp = 2, nrepeat = 1, logratio = "none",
                                 test.keepX = c(5, 10, 15), folds = 2, dist = "max.dist",
-                                BPPARAM = SerialParam(RNGseed = 100))
+                                BPPARAM = SerialParam(), seed = 42)
   
   # run in parallel
-  set.seed(42)
   tune.splsda.res.2 = tune.splsda(X, Y, ncomp = 2, nrepeat = 1, logratio = "none",
                                 test.keepX = c(5, 10, 15), folds = 2, dist = "max.dist",
-                                BPPARAM = SnowParam(RNGseed = 100, workers = 2))
+                                BPPARAM = SnowParam(workers = 2), seed = 42)
   
   # in tune wrapper in serial
-  set.seed(42)
   tune.splsda.res.3 = tune(X, Y, ncomp = 2, nrepeat = 1, logratio = "none",
                                 test.keepX = c(5, 10, 15), folds = 2, dist = "max.dist",
-                                BPPARAM = SerialParam(RNGseed = 100),
+                                BPPARAM = SerialParam(), seed = 42,
                          method = "splsda")
   
   # in tune wrapper in parallel
-  set.seed(42)
   tune.splsda.res.4 = tune(X, Y, ncomp = 2, nrepeat = 1, logratio = "none",
                          test.keepX = c(5, 10, 15), folds = 2, dist = "max.dist",
-                         BPPARAM = SnowParam(RNGseed = 100, workers = 2),
+                         BPPARAM = SnowParam(workers = 2), seed = 42,
                          method = "splsda")
   
   

--- a/tests/testthat/test-tune.splslevel.R
+++ b/tests/testthat/test-tune.splslevel.R
@@ -12,45 +12,41 @@ test_that("tune.splslevel works and is the same in parallel and when run in tune
   design <- data.frame(sample = repeat.indiv)
   
   # run in serial
-  set.seed(42)
   tune.splslevel.res.1<- tune.splslevel(X = liver.toxicity$gene,
                                       Y=liver.toxicity$clinic,
                                       multilevel = design,
                                       test.keepX = c(5,10,15),
                                       test.keepY = c(1,2,5),
                                       ncomp = 1,
-                                      BPPARAM = SerialParam(RNGseed = 42))
+                                      BPPARAM = SerialParam(), seed = 42)
   
   # run in parallel
-  set.seed(42)
   tune.splslevel.res.2<- tune.splslevel(X = liver.toxicity$gene,
                                         Y=liver.toxicity$clinic,
                                         multilevel = design,
                                         test.keepX = c(5,10,15),
                                         test.keepY = c(1,2,5),
                                         ncomp = 1,
-                                        BPPARAM = SnowParam(RNGseed = 42, workers = 2))
+                                        BPPARAM = SnowParam(workers = 2), seed = 42)
   
   # in tune wrapper in serial
-  set.seed(42)
   tune.splslevel.res.3<- tune(X = liver.toxicity$gene,
                                         Y=liver.toxicity$clinic,
                                         multilevel = design,
                                         test.keepX = c(5,10,15),
                                         test.keepY = c(1,2,5),
                                         ncomp = 1,
-                                        BPPARAM = SerialParam(RNGseed = 42),
+                                        BPPARAM = SerialParam(), seed = 42,
                               method = "spls")
   
   # in tune wrapper in parallel
-  set.seed(42)
   tune.splslevel.res.4<- tune(X = liver.toxicity$gene,
                               Y=liver.toxicity$clinic,
                               multilevel = design,
                               test.keepX = c(5,10,15),
                               test.keepY = c(1,2,5),
                               ncomp = 1,
-                              BPPARAM = SnowParam(RNGseed = 42, workers = 2),
+                              BPPARAM = SnowParam(workers = 2), seed = 42,
                               method = "spls")
   
   


### PR DESCRIPTION
Added seed arguments to all tune functions except MINT which does not use randomness or parallelisation. 

✅ Added seed arg to tune() wrapper function and the internal functions it calls and pass this into BPPARAM. Ensure that setting this seed is sufficient for reproducible activity (i.e. you don't also have to set.seed() globally, if you do also need to incorporate this into the function).
✅ Set the default as seed = NULL so usually does not run reproducibly
✅ Updated testing to make sure all tune() functions run reproducibly

For:
✅ tune.spca()
✅ tune.spls()
✅ tune.spls1()
✅ tune.splsda()
✅ tune.splslevel()
✅ tune.rcc()
✅ tune.block.splsda()