### PR TITLE
353 perf assess cleanup

### DIFF
--- a/R/perf.assess.R
+++ b/R/perf.assess.R
@@ -94,9 +94,6 @@
 #' performance of the model.
 #' @param progressBar by default set to \code{FALSE} to output the progress bar
 #' of the computation.
-#' @param signif.threshold numeric between 0 and 1 indicating the significance
-#' threshold required for improvement in error rate of the components. Default
-#' to 0.01.
 #' @template arg/BPPARAM 
 #' @param seed set a number here if you want the function to give reproducible outputs. 
 #' Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'. 

--- a/R/perf.assess.diablo.R
+++ b/R/perf.assess.diablo.R
@@ -37,13 +37,12 @@
 #' @export
 perf.assess.sgccda <- 
   function (object,
-            dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
             validation = c("Mfold", "loo"),
-            folds = 10,
+            folds,
             nrepeat = 1,
+            dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
             auc = FALSE,
             progressBar = FALSE,
-            signif.threshold = 0.01,
             BPPARAM = SerialParam(),
             seed = NULL,
             ...)

--- a/R/perf.assess.diablo.R
+++ b/R/perf.assess.diablo.R
@@ -38,7 +38,7 @@
 perf.assess.sgccda <- 
   function (object,
             validation = c("Mfold", "loo"),
-            folds,
+            folds = 3,
             nrepeat = 1,
             dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
             auc = FALSE,

--- a/R/perf.assess.diablo.R
+++ b/R/perf.assess.diablo.R
@@ -77,9 +77,6 @@ perf.assess.sgccda <-
     
     ### Start: Check parameter validation / set up sample
     
-    #-- check significance threshold
-    signif.threshold <- .check_alpha(signif.threshold)
-    
     if (length(validation) > 1 )
       validation = validation [1]
     

--- a/R/perf.assess.diablo.R
+++ b/R/perf.assess.diablo.R
@@ -71,6 +71,12 @@ perf.assess.sgccda <-
     } else {
       dist.select = dist
     }
+
+    if (any(table(object$Y) <= 1)) {
+      stop(paste("Cannot evaluate performance when a class level ('", 
+                names(table(object$Y))[which(table(object$Y) == 1)],
+                "') has only a single associated sample.", sep = ""))
+    }
     ### End: Initialization parameters
     
     dist = match.arg(dist.select, choices = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"), several.ok = TRUE)

--- a/R/perf.assess.mint.plsda.R
+++ b/R/perf.assess.mint.plsda.R
@@ -72,6 +72,12 @@ perf.assess.mint.plsda <- function (object,
         stop("'progressBar' must be either TRUE or FALSE")
 
     near.zero.var = !is.null(object$nzv) # if near.zero.var was used, we set it to TRUE. if not used, object$nzv is NULL
+
+    if (any(table(object$Y) <= 1)) {
+      stop(paste("Cannot evaluate performance when a class level ('", 
+                names(table(object$Y))[which(table(object$Y) == 1)],
+                "') has only a single associated sample.", sep = ""))
+    }
     
     #-- end checking --#
     #------------------#

--- a/R/perf.assess.mint.plsda.R
+++ b/R/perf.assess.mint.plsda.R
@@ -41,7 +41,6 @@ perf.assess.mint.plsda <- function (object,
                              dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
                              auc = FALSE,
                              progressBar = FALSE,
-                             signif.threshold = 0.01,
                              ...
 )
 {   #-- checking general input parameters --------------------------------------#

--- a/R/perf.assess.mint.plsda.R
+++ b/R/perf.assess.mint.plsda.R
@@ -70,9 +70,6 @@ perf.assess.mint.plsda <- function (object,
     
     if (!is.logical(progressBar))
         stop("'progressBar' must be either TRUE or FALSE")
-    
-    #-- check significance threshold
-    signif.threshold <- .check_alpha(signif.threshold)
 
     near.zero.var = !is.null(object$nzv) # if near.zero.var was used, we set it to TRUE. if not used, object$nzv is NULL
     

--- a/R/perf.assess.pls.R
+++ b/R/perf.assess.pls.R
@@ -58,10 +58,8 @@ perf.assess.mixo_pls <- function(object,
         .perf.assess.mixo_pls_cv(object, validation = validation, folds = folds, nrep = nrep)
     }, BPPARAM = BPPARAM)
     
-    measures <- lapply(result, function(x){
-        x$measures
-    })
-    
+    # extract measures
+    measures <- lapply(result, function(x){x$measures})
     measures <- Reduce(rbind, measures)
     measures <- as.data.frame(measures)
 
@@ -72,6 +70,7 @@ perf.assess.mixo_pls <- function(object,
     measure <- feature <- comp <- block <- stability <- value <- NULL
     lower <- upper <- keepX <- keepY <- NULL
     
+    # extract measures
     measure.names <- .name_list(unique(measures$measure))
     measures <- lapply(measure.names, function(meas) {
         ## ------ value of measures across repeats

--- a/R/perf.assess.pls.R
+++ b/R/perf.assess.pls.R
@@ -36,8 +36,8 @@
 perf.assess.mixo_pls <- function(object,
                           validation = c("Mfold", "loo"),
                           folds,
-                          progressBar = FALSE,
                           nrepeat = 1,
+                          progressBar = FALSE,
                           BPPARAM = SerialParam(),
                           seed = NULL,
                           ...)
@@ -53,8 +53,7 @@ perf.assess.mixo_pls <- function(object,
     repeat_names <- .name_list(char = seq_len(nrepeat))
     result <- bplapply(X = repeat_names, FUN = function(nrep) {
         ## progress bar
-        if (progressBar == TRUE)
-            .progressBar(nrep/nrepeat)
+        if (progressBar == TRUE){.progressBar(nrep/nrepeat)}
         ## CV
         .perf.assess.mixo_pls_cv(object, validation = validation, folds = folds, nrep = nrep)
     }, BPPARAM = BPPARAM)

--- a/R/perf.assess.plsda.R
+++ b/R/perf.assess.plsda.R
@@ -117,9 +117,6 @@ perf.assess.mixo_plsda <- function(object,
         stop("Choose one of the two following logratio transformation: 'none' or 'CLR'")
     #fold is checked in 'MCVfold'
     
-    #-- check significance threshold
-    signif.threshold <- .check_alpha(signif.threshold)
-    
     #---------------------------------------------------------------------------#
     #-- logration + multilevel approach ----------------------------------------#
 

--- a/R/perf.assess.plsda.R
+++ b/R/perf.assess.plsda.R
@@ -34,13 +34,12 @@
 #' @method perf.assess mixo_plsda
 #' @export
 perf.assess.mixo_plsda <- function(object,
-                            dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
                             validation = c("Mfold", "loo"),
                             folds = 10,
-                            nrepeat = 1,
+                            nrepeat = 10,
+                            dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
                             auc = FALSE,
                             progressBar = FALSE,
-                            signif.threshold = 0.01,
                             BPPARAM = SerialParam(),
                             seed = NULL,
                             ...)

--- a/R/perf.assess.plsda.R
+++ b/R/perf.assess.plsda.R
@@ -35,8 +35,8 @@
 #' @export
 perf.assess.mixo_plsda <- function(object,
                             validation = c("Mfold", "loo"),
-                            folds = 10,
-                            nrepeat = 10,
+                            folds,
+                            nrepeat = 1,
                             dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
                             auc = FALSE,
                             progressBar = FALSE,

--- a/R/tune.plsda.R
+++ b/R/tune.plsda.R
@@ -69,34 +69,33 @@
 #' @param Y \code{if(method = 'spls')} numeric vector or matrix of continuous
 #' responses (for multi-response models) \code{NA}s are allowed.
 #' @param ncomp the number of components to include in the model.
-#' @param validation character. What kind of (internal) validation to use,
-#'   matching one of \code{"Mfold"} or \code{"loo"} (short for 'leave-one-out').
-#'   Default is \code{"Mfold"}.
-#' @param folds the folds in the Mfold cross-validation. See Details.
-#' @param dist distance metric to use for \code{splsda} to estimate the
-#' classification error rate, should be a subset of \code{"centroids.dist"},
-#' \code{"mahalanobis.dist"} or \code{"max.dist"} (see Details).
 #' @param scale Logical. If scale = TRUE, each block is standardized to zero
 #' means and unit variances (default: TRUE)
-#' @param auc if \code{TRUE} calculate the Area Under the Curve (AUC)
-#' @param progressBar by default set to \code{TRUE} to output the progress bar
-#' of the computation.
 #' @param tol Convergence stopping value.
 #' @param max.iter integer, the maximum number of iterations.
 #' @param near.zero.var Logical, see the internal \code{\link{nearZeroVar}}
 #' function (should be set to TRUE in particular for data with many zero
 #' values). Default value is FALSE
-#' @param nrepeat Number of times the Cross-Validation process is repeated.
 #' @param logratio one of ('none','CLR'). Default to 'none'
 #' @param multilevel Design matrix for multilevel analysis (for repeated
 #' measurements) that indicates the repeated measures on each individual, i.e.
 #' the individuals ID. See Details.
-#' @param light.output if set to FALSE, the prediction/classification of each
-#' sample for each of \code{test.keepX} and each comp is returned.
+#' @param validation character. What kind of (internal) validation to use,
+#'   matching one of \code{"Mfold"} or \code{"loo"} (short for 'leave-one-out').
+#'   Default is \code{"Mfold"}.
+#' @param folds the folds in the Mfold cross-validation. See Details.
+#' @param nrepeat Number of times the Cross-Validation process is repeated.
+#' @param dist distance metric to use for \code{splsda} to estimate the
+#' classification error rate, should be a subset of \code{"centroids.dist"},
+#' \code{"mahalanobis.dist"} or \code{"max.dist"} (see Details).
 #' @param signif.threshold numeric between 0 and 1 indicating the significance
 #' threshold required for improvement in error rate of the components. Default
 #' to 0.01.
-#' @param dist Distance metric. Should be a subset of "max.dist", "centroids.dist", "mahalanobis.dist" or "all". Default is "all"
+#' @param auc if \code{TRUE} calculate the Area Under the Curve (AUC)
+#' @param progressBar by default set to \code{TRUE} to output the progress bar
+#' of the computation.
+#' @param light.output if set to FALSE, the prediction/classification of each
+#' sample for each of \code{test.keepX} and each comp is returned.
 #' @template arg/BPPARAM
 #' @param seed set a number here if you want the function to give reproducible outputs. 
 #' Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'. 

--- a/R/tune.splsda.R
+++ b/R/tune.splsda.R
@@ -84,10 +84,22 @@
 #' @param already.tested.X Optional, if \code{ncomp > 1} A numeric vector
 #' indicating the number of variables to select from the \eqn{X} data set on
 #' the firsts components.
+#' @param scale Logical. If scale = TRUE, each block is standardized to zero
+#' means and unit variances (default: TRUE)
+#' @param tol Convergence stopping value.
+#' @param max.iter integer, the maximum number of iterations.
+#' @param near.zero.var Logical, see the internal \code{\link{nearZeroVar}}
+#' function (should be set to TRUE in particular for data with many zero
+#' values). Default value is FALSE
+#' @param logratio one of ('none','CLR'). Default to 'none'
+#' @param multilevel Design matrix for multilevel analysis (for repeated
+#' measurements) that indicates the repeated measures on each individual, i.e.
+#' the individuals ID. See Details.
 #' @param validation character. What kind of (internal) validation to use,
 #'   matching one of \code{"Mfold"} or \code{"loo"} (short for 'leave-one-out').
 #'   Default is \code{"Mfold"}.
 #' @param folds the folds in the Mfold cross-validation. See Details.
+#' @param nrepeat Number of times the Cross-Validation process is repeated.
 #' @param dist distance metric to use for \code{splsda} to estimate the
 #' classification error rate, should one of \code{"centroids.dist"},
 #' \code{"mahalanobis.dist"} or \code{"max.dist"} (see Details). 
@@ -95,27 +107,15 @@
 #' @param measure Three misclassification measure are available: overall
 #' misclassification error \code{overall}, the Balanced Error Rate \code{BER}
 #' or the Area Under the Curve \code{AUC}. Only used when \code{test.keepX} is not NULL. 
-#' @param scale Logical. If scale = TRUE, each block is standardized to zero
-#' means and unit variances (default: TRUE)
+#' @param signif.threshold numeric between 0 and 1 indicating the significance
+#' threshold required for improvement in error rate of the components. Default
+#' to 0.01.
 #' @param auc if \code{TRUE} calculate the Area Under the Curve (AUC)
 #' performance of the model based on the optimisation measure \code{measure}.
 #' @param progressBar by default set to \code{TRUE} to output the progress bar
 #' of the computation.
-#' @param tol Convergence stopping value.
-#' @param max.iter integer, the maximum number of iterations.
-#' @param near.zero.var Logical, see the internal \code{\link{nearZeroVar}}
-#' function (should be set to TRUE in particular for data with many zero
-#' values). Default value is FALSE
-#' @param nrepeat Number of times the Cross-Validation process is repeated.
-#' @param logratio one of ('none','CLR'). Default to 'none'
-#' @param multilevel Design matrix for multilevel analysis (for repeated
-#' measurements) that indicates the repeated measures on each individual, i.e.
-#' the individuals ID. See Details.
 #' @param light.output if set to FALSE, the prediction/classification of each
 #' sample for each of \code{test.keepX} and each comp is returned.
-#' @param signif.threshold numeric between 0 and 1 indicating the significance
-#' threshold required for improvement in error rate of the components. Default
-#' to 0.01.
 #' @template arg/BPPARAM
 #' @param seed set a number here if you want the function to give reproducible outputs. 
 #' Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'. 

--- a/examples/perf.assess-examples.R
+++ b/examples/perf.assess-examples.R
@@ -55,7 +55,10 @@ data("breast.TCGA")
 mrna <- breast.TCGA$data.train$mrna
 mirna <- breast.TCGA$data.train$mirna
 data <- list(mrna = mrna, mirna = mirna)
-design <- matrix(1, ncol = length(data), nrow = length(data), dimnames = list(names(data), names(data)))
+design <- matrix(1, 
+   ncol = length(data), 
+   nrow = length(data), 
+   dimnames = list(names(data), names(data)))
 diag(design) <-  0
 
 block.plsda.res <- block.plsda(X = data, Y = breast.TCGA$data.train$subtype, 

--- a/man/perf.assess.Rd
+++ b/man/perf.assess.Rd
@@ -345,7 +345,10 @@ data("breast.TCGA")
 mrna <- breast.TCGA$data.train$mrna
 mirna <- breast.TCGA$data.train$mirna
 data <- list(mrna = mrna, mirna = mirna)
-design <- matrix(1, ncol = length(data), nrow = length(data), dimnames = list(names(data), names(data)))
+design <- matrix(1, 
+   ncol = length(data), 
+   nrow = length(data), 
+   dimnames = list(names(data), names(data)))
 diag(design) <-  0
 
 block.plsda.res <- block.plsda(X = data, Y = breast.TCGA$data.train$subtype, 

--- a/man/perf.assess.Rd
+++ b/man/perf.assess.Rd
@@ -50,8 +50,8 @@ perf.assess(object, ...)
   object,
   validation = c("Mfold", "loo"),
   folds,
-  progressBar = FALSE,
   nrepeat = 1,
+  progressBar = FALSE,
   BPPARAM = SerialParam(),
   seed = NULL,
   ...
@@ -61,8 +61,8 @@ perf.assess(object, ...)
   object,
   validation = c("Mfold", "loo"),
   folds,
-  progressBar = FALSE,
   nrepeat = 1,
+  progressBar = FALSE,
   BPPARAM = SerialParam(),
   seed = NULL,
   ...

--- a/man/perf.assess.Rd
+++ b/man/perf.assess.Rd
@@ -16,13 +16,12 @@ perf.assess(object, ...)
 
 \method{perf.assess}{sgccda}(
   object,
-  dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
   validation = c("Mfold", "loo"),
-  folds = 10,
+  folds,
   nrepeat = 1,
+  dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
   auc = FALSE,
   progressBar = FALSE,
-  signif.threshold = 0.01,
   BPPARAM = SerialParam(),
   seed = NULL,
   ...
@@ -33,7 +32,6 @@ perf.assess(object, ...)
   dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
   auc = FALSE,
   progressBar = FALSE,
-  signif.threshold = 0.01,
   ...
 )
 
@@ -42,7 +40,6 @@ perf.assess(object, ...)
   dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
   auc = FALSE,
   progressBar = FALSE,
-  signif.threshold = 0.01,
   ...
 )
 
@@ -71,8 +68,8 @@ perf.assess(object, ...)
 \method{perf.assess}{mixo_plsda}(
   object,
   validation = c("Mfold", "loo"),
-  folds = 10,
-  nrepeat = 10,
+  folds,
+  nrepeat = 1,
   dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
   auc = FALSE,
   progressBar = FALSE,
@@ -84,8 +81,8 @@ perf.assess(object, ...)
 \method{perf.assess}{mixo_splsda}(
   object,
   validation = c("Mfold", "loo"),
-  folds = 10,
-  nrepeat = 10,
+  folds,
+  nrepeat = 1,
   dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
   auc = FALSE,
   progressBar = FALSE,
@@ -101,12 +98,6 @@ retrieve some key parameters stored in that object.}
 
 \item{...}{not used}
 
-\item{dist}{only applies to an object inheriting from \code{"plsda"},
-\code{"splsda"} or \code{"mint.splsda"} to evaluate the classification
-performance of the model. Should be a subset of \code{"max.dist"},
-\code{"centroids.dist"}, \code{"mahalanobis.dist"}. Default is \code{"all"}.
-See \code{\link{predict}}.}
-
 \item{validation}{a character string.  What kind of (internal) validation to use,
 matching one of \code{"Mfold"} or \code{"loo"} (see below). Default is
 \code{"Mfold"}. For MINT methods only \code{"loo"} will be used.}
@@ -117,15 +108,17 @@ matching one of \code{"Mfold"} or \code{"loo"} (see below). Default is
 This is an important argument to ensure the estimation of the performance to
 be as accurate as possible. Default it 1.}
 
+\item{dist}{only applies to an object inheriting from \code{"plsda"},
+\code{"splsda"} or \code{"mint.splsda"} to evaluate the classification
+performance of the model. Should be a subset of \code{"max.dist"},
+\code{"centroids.dist"}, \code{"mahalanobis.dist"}. Default is \code{"all"}.
+See \code{\link{predict}}.}
+
 \item{auc}{if \code{TRUE} calculate the Area Under the Curve (AUC)
 performance of the model.}
 
 \item{progressBar}{by default set to \code{FALSE} to output the progress bar
 of the computation.}
-
-\item{signif.threshold}{numeric between 0 and 1 indicating the significance
-threshold required for improvement in error rate of the components. Default
-to 0.01.}
 
 \item{BPPARAM}{A \linkS4class{BiocParallelParam} object indicating the type
 of parallelisation. See examples in \code{?tune.spca}.}
@@ -133,6 +126,10 @@ of parallelisation. See examples in \code{?tune.spca}.}
 \item{seed}{set a number here if you want the function to give reproducible outputs. 
 Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'. 
 Note 'seed' is not required or used in perf.mint.plsda as this method uses loo cross-validation}
+
+\item{signif.threshold}{numeric between 0 and 1 indicating the significance
+threshold required for improvement in error rate of the components. Default
+to 0.01.}
 }
 \value{
 For PLS and sPLS models:

--- a/man/perf.assess.Rd
+++ b/man/perf.assess.Rd
@@ -17,7 +17,7 @@ perf.assess(object, ...)
 \method{perf.assess}{sgccda}(
   object,
   validation = c("Mfold", "loo"),
-  folds,
+  folds = 3,
   nrepeat = 1,
   dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
   auc = FALSE,
@@ -126,10 +126,6 @@ of parallelisation. See examples in \code{?tune.spca}.}
 \item{seed}{set a number here if you want the function to give reproducible outputs. 
 Not recommended during exploratory analysis. Note if RNGseed is set in 'BPPARAM', this will be overwritten by 'seed'. 
 Note 'seed' is not required or used in perf.mint.plsda as this method uses loo cross-validation}
-
-\item{signif.threshold}{numeric between 0 and 1 indicating the significance
-threshold required for improvement in error rate of the components. Default
-to 0.01.}
 }
 \value{
 For PLS and sPLS models:

--- a/man/perf.assess.Rd
+++ b/man/perf.assess.Rd
@@ -70,13 +70,12 @@ perf.assess(object, ...)
 
 \method{perf.assess}{mixo_plsda}(
   object,
-  dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
   validation = c("Mfold", "loo"),
   folds = 10,
-  nrepeat = 1,
+  nrepeat = 10,
+  dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
   auc = FALSE,
   progressBar = FALSE,
-  signif.threshold = 0.01,
   BPPARAM = SerialParam(),
   seed = NULL,
   ...
@@ -84,13 +83,12 @@ perf.assess(object, ...)
 
 \method{perf.assess}{mixo_splsda}(
   object,
-  dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
   validation = c("Mfold", "loo"),
   folds = 10,
-  nrepeat = 1,
+  nrepeat = 10,
+  dist = c("all", "max.dist", "centroids.dist", "mahalanobis.dist"),
   auc = FALSE,
   progressBar = FALSE,
-  signif.threshold = 0.01,
   BPPARAM = SerialParam(),
   seed = NULL,
   ...

--- a/man/tune.plsda.Rd
+++ b/man/tune.plsda.Rd
@@ -63,7 +63,9 @@ Default is \code{"Mfold"}.}
 threshold required for improvement in error rate of the components. Default
 to 0.01.}
 
-\item{dist}{Distance metric. Should be a subset of "max.dist", "centroids.dist", "mahalanobis.dist" or "all". Default is "all"}
+\item{dist}{distance metric to use for \code{splsda} to estimate the
+classification error rate, should be a subset of \code{"centroids.dist"},
+\code{"mahalanobis.dist"} or \code{"max.dist"} (see Details).}
 
 \item{auc}{if \code{TRUE} calculate the Area Under the Curve (AUC)}
 

--- a/tests/testthat/test-perf.and.perf.assess.mint.plsda.R
+++ b/tests/testthat/test-perf.and.perf.assess.mint.plsda.R
@@ -1,4 +1,4 @@
-context("perf.mint.plsda")
+context("perf.assess.mint.plsda")
 library(BiocParallel)
 
 ## ------------------------------------------------------------------------ ##
@@ -41,6 +41,25 @@ test_that("perf.mint.splsda works with custom alpha", code = {
     expect_true(all(out$choice.ncomp == 1))
     
 })
+
+## ------------------------------------------------------------------------ ##
+## Test perf.assess.mixo_plsda() give informative error message when one sample in one class
+# can't run this because get error message already when try to build model like this
+
+# test_that("perf.assess.mixo_plsda error when one sample in one class", code = {
+#   
+#   data(stemcells)
+#   res = mint.splsda(
+#     X = stemcells$gene[1:33,],
+#     Y = stemcells$celltype[1:33],
+#     ncomp = 3,
+#     keepX = c(5, 10, 15),
+#     study = stemcells$study[1:33]
+#   )
+#   
+#   Error in internal_wrapper.mint(X = X, Y = Y.mat, ncomp = ncomp, near.zero.var = near.zero.var,  : 
+#   At least one study has only one sample, please consider removing before calling the function again
+# })
 
 # test_that("perf.mint.splsda and tune.mint.splsda yield the same error rates for all measures", code = {
 #     data(stemcells)

--- a/tests/testthat/test-perf.and.perf.assess.mixo.plsR.R
+++ b/tests/testthat/test-perf.and.perf.assess.mixo.plsR.R
@@ -1,4 +1,4 @@
-context("perf.mixo.pls")
+context("perf.assess.mixo.pls")
 library(BiocParallel)
 
 ## ------------------------------------------------------------------------ ##

--- a/tests/testthat/test-perf.and.perf.assess.mixo.plsda.R
+++ b/tests/testthat/test-perf.and.perf.assess.mixo.plsda.R
@@ -1,4 +1,4 @@
-context("perf.mixo.plsda")
+context("perf.assess.mixo.plsda")
 library(BiocParallel)
 
 ## ------------------------------------------------------------------------ ##
@@ -102,7 +102,7 @@ test_that("perf.assess.mixo_splsda works same as perf for same components in ser
 })
 
 ## ------------------------------------------------------------------------ ##
-## Test perf.mixo_plsda() and perf.assess.mixo_plsda() give informative error message when one sample in one class
+## Test perf.assess.mixo_plsda() give informative error message when one sample in one class
 
 test_that("perf.assess.mixo_plsda error when one sample in one class", code = {
   
@@ -114,7 +114,7 @@ test_that("perf.assess.mixo_plsda error when one sample in one class", code = {
   
   # Execution using old perf() function in serial
   test_run <- function() {
-    perf(res, validation = "Mfold", folds = 2, nrepeat = 1, BPPARAM = SerialParam(), seed = 12)}
+    perf.assess(res, validation = "Mfold", folds = 2, nrepeat = 1, BPPARAM = SerialParam(), seed = 12)}
   
   expect_error(test_run(), 
                "Cannot evaluate performance when a class level ('2000') has only a single associated sample.",

--- a/tests/testthat/test-perf.and.perf.assess.mixo.plsda.R
+++ b/tests/testthat/test-perf.and.perf.assess.mixo.plsda.R
@@ -100,3 +100,23 @@ test_that("perf.assess.mixo_splsda works same as perf for same components in ser
   expect_equal(as.vector(out.1$error.rate$overall[2,]), as.vector(out.3$error.rate$overall))
 
 })
+
+## ------------------------------------------------------------------------ ##
+## Test perf.mixo_plsda() and perf.assess.mixo_plsda() give informative error message when one sample in one class
+
+test_that("perf.assess.mixo_plsda error when one sample in one class", code = {
+  
+  # set up data and model
+  data(liver.toxicity)
+  X <- liver.toxicity$gene[1:49, ]
+  Y <- liver.toxicity$treatment$Dose.Group[1:49]
+  res <- plsda(X, Y, ncomp = 2)
+  
+  # Execution using old perf() function in serial
+  test_run <- function() {
+    perf(res, validation = "Mfold", folds = 2, nrepeat = 1, BPPARAM = SerialParam(), seed = 12)}
+  
+  expect_error(test_run(), 
+               "Cannot evaluate performance when a class level ('2000') has only a single associated sample.",
+               fixed = TRUE)
+})


### PR DESCRIPTION
Added extra checks in `perf.assess.plsda`, `perf.assess.sgcda`, `perf.assess.mint.plsda` to check and error if there is one sample in one class. Added unit tests to check these error messages. 