### PR TITLE
PR addressing Issue #379

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Imports:
     ggrepel,
     BiocParallel,
     utils,
-    gsignal,
     rgl,
     rlang
 Suggests: 

--- a/R/S3methods-plot.perf.pls.R
+++ b/R/S3methods-plot.perf.pls.R
@@ -110,7 +110,7 @@ plot.perf.pls.mthd <-
             # min.y <- ifelse(repeated, min(df$lower), min(df$mean))
             # max.y <- ifelse(repeated, max(df$upper), max(df$mean))
             # y.breaks <- sort(c(round(seq(min.y, max.y, length.out=5), 2), LimQ2))
-            p <- p + geom_hline(yintercept = LimQ2, col = LimQ2.col, size  = 1.3) #+
+            p <- p + geom_hline(yintercept = LimQ2, col = LimQ2.col, linewidth  = 1.3) #+
             # geom_text(x = max(df$comp), y = 0.0975, label = 'Q2 = 0.0975', hjust=1, vjust=-0.5)
             # scale_y_continuous(breaks = y.breaks)
         }

--- a/R/biplot.R
+++ b/R/biplot.R
@@ -106,11 +106,11 @@ NULL
         ## vline and hline
         if (vline)
         {
-            gg_biplot <- gg_biplot + geom_vline(xintercept = 0, size = 0.3, col = 'grey75')
+            gg_biplot <- gg_biplot + geom_vline(xintercept = 0, linewidth = 0.3, col = 'grey75')
         }
         if (hline)
         {
-            gg_biplot <- gg_biplot +  geom_hline(yintercept = 0, size = 0.3, col = 'grey75')
+            gg_biplot <- gg_biplot +  geom_hline(yintercept = 0, linewidth = 0.3, col = 'grey75')
         }
         
         

--- a/R/mixOmics-package.R
+++ b/R/mixOmics-package.R
@@ -1,4 +1,4 @@
-#' 'Omics Data Integration Project
+#' Omics Data Integration Project
 #'
 #' Multivariate methods are well suited to large omics data sets where the
 #' number of variables (e.g. genes, proteins, metabolites) is much larger than
@@ -7,8 +7,8 @@
 #' variables (components), which are defined as combinations of all variables.
 #' Those components are then used to produce useful graphical outputs that
 #' enable better understanding of the relationships and correlation structures
-#' between the different data sets that are integrated. 
-#' 
+#' between the different data sets that are integrated.
+#'
 #' mixOmics offers a wide
 #' range of multivariate methods for the exploration and integration of
 #' biological datasets with a particular focus on variable selection. The
@@ -17,8 +17,8 @@
 #' biological outcome of interest. The data that can be analysed with mixOmics
 #' may come from high throughput sequencing technologies, such as omics data
 #' (transcriptomics, metabolomics, proteomics, metagenomics etc) but also beyond
-#' the realm of omics (e.g. spectral imaging). 
-#' 
+#' the realm of omics (e.g. spectral imaging).
+#'
 #' The methods implemented in
 #' mixOmics can also handle missing values without having to delete entire rows
 #' with missing data. A non exhaustive list of methods include variants of
@@ -28,10 +28,7 @@
 #' Canonical Correlation Analysis and P-integration with variants of multi-group
 #' Partial Least Squares.
 #'
-#' @docType package
-#' @name mixOmics-package
-NULL
-
+#' @aliases mixOmics-package
 #' @import MASS lattice igraph ggplot2 corpcor parallel RColorBrewer
 #' @importFrom grDevices as.graphicsAnnot chull col2rgb colorRamp colorRampPalette colors dev.cur dev.new dev.off dev.prev dev.set devAskNewPage graphics.off gray gray.colors heat.colors rgb jpeg pdf tiff x11 adjustcolor rainbow
 #' @importFrom graphics abline arrows axis barplot box image layout legend lines locator mtext par plot plot.default points polygon rect segments strheight strwidth symbols text title Axis boxplot rasterImage matplot
@@ -39,5 +36,4 @@ NULL
 #' @importFrom utils setTxtProgressBar txtProgressBar
 #' @importFrom dplyr arrange rename filter group_by mutate n row_number summarise ungroup
 #' @importFrom rlang .data
-#' @noRd
-NULL
+"_PACKAGE"

--- a/R/plotLoadings.R
+++ b/R/plotLoadings.R
@@ -32,7 +32,7 @@
 #' The \code{block} argument behavior varies depending on the object type. 
 #' For \code{mixo_pls}, \code{mixo_spls}, \code{rcc}, \code{rgcca}, \code{sgcca},
 #' \code{block} can be any number of blocks from \code{object$names$blocks}.
-#' For code{mint.pls}, \code{mint.spls}: when \code{study="all.partial"}, 
+#' For \code{mint.pls}, \code{mint.spls}: when \code{study="all.partial"},
 #' can only be one block from \code{object$names$blocks}.
 #' 
 #' @aliases plotLoadings.pls plotLoadings.spls

--- a/R/utils.R
+++ b/R/utils.R
@@ -651,7 +651,7 @@ mixo_gg.theme <- function(cex, x.angle = 90, background.fill = 'grey97', subtitl
     theme(panel.border = element_blank(),
           panel.grid.major = element_blank(),
           panel.grid.minor = element_blank(),
-          axis.line = element_line(size = 0.5, linetype = "solid",
+          axis.line = element_line(linewidth = 0.5, linetype = "solid",
                                    colour = "black"),
           panel.background = element_rect(fill = background.fill),
           

--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ Thank you!
   [\#374](https://github.com/mixOmicsTeam/mixOmics/issues/374) replaced
   deprecated `aes_string()` with `aes(.data[[...]])` in plotting
   functions
+- bug fix implemented for
+  [\#379](https://github.com/mixOmicsTeam/mixOmics/issues/379) replaced
+  deprecated `size` aesthetic with `linewidth` in ggplot2 line geoms
 
 #### April 2025
 

--- a/inst/README-WhatsNew.Rmd
+++ b/inst/README-WhatsNew.Rmd
@@ -20,6 +20,7 @@ opts_chunk$set( echo = TRUE, eval = FALSE, warning = FALSE, message = FALSE)
 #### April 2026
 
 * bug fix implemented for [#374](https://github.com/mixOmicsTeam/mixOmics/issues/374) replaced deprecated `aes_string()` with `aes(.data[[...]])` in plotting functions
+* bug fix implemented for [#379](https://github.com/mixOmicsTeam/mixOmics/issues/379) replaced deprecated `size` aesthetic with `linewidth` in ggplot2 line geoms
 
 #### April 2025
 ** Version 6.32.0 **

--- a/man/mixOmics-package.Rd
+++ b/man/mixOmics-package.Rd
@@ -3,7 +3,7 @@
 \docType{package}
 \name{mixOmics-package}
 \alias{mixOmics-package}
-\title{'Omics Data Integration Project}
+\title{Omics Data Integration Project}
 \description{
 Multivariate methods are well suited to large omics data sets where the
 number of variables (e.g. genes, proteins, metabolites) is much larger than
@@ -23,7 +23,7 @@ identify the key variables that are highly correlated, and/or explain the
 biological outcome of interest. The data that can be analysed with mixOmics
 may come from high throughput sequencing technologies, such as omics data
 (transcriptomics, metabolomics, proteomics, metagenomics etc) but also beyond
-the realm of omics (e.g. spectral imaging). 
+the realm of omics (e.g. spectral imaging).
 
 The methods implemented in
 mixOmics can also handle missing values without having to delete entire rows

--- a/man/plotLoadings.Rd
+++ b/man/plotLoadings.Rd
@@ -476,7 +476,7 @@ layout design.
 The \code{block} argument behavior varies depending on the object type. 
 For \code{mixo_pls}, \code{mixo_spls}, \code{rcc}, \code{rgcca}, \code{sgcca},
 \code{block} can be any number of blocks from \code{object$names$blocks}.
-For code{mint.pls}, \code{mint.spls}: when \code{study="all.partial"}, 
+For \code{mint.pls}, \code{mint.spls}: when \code{study="all.partial"},
 can only be one block from \code{object$names$blocks}.
 }
 \examples{

--- a/tests/testthat/test-biplot.R
+++ b/tests/testthat/test-biplot.R
@@ -65,12 +65,12 @@ plsda.breast <- plsda(X, Y, ncomp = 2)
 
 test_that("biplot works for plsda objects", {
   skip_on_ci() # only run the vdiffr tests locally
-  
+
   # simple plot showing sample names
   set.seed(100)
   invisible(capture.output(
     expect_doppelganger(
-      title = "biplot plot plsda model control pch", 
+      title = "biplot plot plsda model control pch",
       fig = biplot(plsda.breast, cutoff = 0.72, ind.names = FALSE, pch = 2, pch.size = 5))
   ))
 
@@ -82,4 +82,11 @@ test_that("biplot works for plsda objects", {
   #     title = "biplot plot plsda model with customised pch",
   #     fig = biplot(plsda.breast, cutoff = 0.72, pch = grouping, pch.size = 5))
   # ))
+})
+
+## ------------------------------------------------------------------------ ##
+## Regression guard: ggplot2 size -> linewidth
+
+test_that("(biplot:edge.case): no ggplot2 size-aesthetic deprecation warning", {
+  expect_no_warning(biplot(plsda.breast))
 })

--- a/tests/testthat/test-biplot.R
+++ b/tests/testthat/test-biplot.R
@@ -88,5 +88,6 @@ test_that("biplot works for plsda objects", {
 ## Regression guard: ggplot2 size -> linewidth
 
 test_that("(biplot:edge.case): no ggplot2 size-aesthetic deprecation warning", {
-  expect_no_warning(biplot(plsda.breast))
+  # vline/hline default to FALSE; enable them to exercise the linewidth code paths
+  expect_no_warning(biplot(plsda.breast, vline = TRUE, hline = TRUE))
 })

--- a/tests/testthat/test-perf.and.perf.assess.mixo.plsR.R
+++ b/tests/testthat/test-perf.and.perf.assess.mixo.plsR.R
@@ -146,3 +146,16 @@ test_that("perf gives error for invariant mode", code = {
   expect_error(perf.assess(spls.obj), "BiocParallel errors.*mode 'invariant'", fixed = FALSE)
 
   })
+
+## ------------------------------------------------------------------------ ##
+## Regression guard: ggplot2 size -> linewidth
+
+test_that("(plot.perf.pls:edge.case): no ggplot2 size-aesthetic deprecation warning (Q2 criterion)", {
+  data("liver.toxicity")
+  X <- liver.toxicity$gene[1:100]
+  Y <- liver.toxicity$clinic
+  pls.mod  <- pls(X, Y, ncomp = 2)
+  perf.obj <- perf(pls.mod, validation = "Mfold", folds = 2, nrepeat = 1,
+                   progressBar = FALSE)
+  expect_no_warning(plot(perf.obj, criterion = "Q2.total"))
+})


### PR DESCRIPTION
## Summary

Addresses #379 by replacing the deprecated `size` aesthetic with `linewidth` in ggplot2 line geoms (`geom_hline`, `geom_vline`, `element_line`), removing deprecation warnings raised since [ggplot2 3.4.0](https://tidyverse.org/blog/2022/11/ggplot2-3-4-0/).

## Changes

- `R/S3methods-plot.perf.pls.R` — 1 occurrence (`geom_hline()` for the `LimQ2` threshold in `plot.perf.pls`)
- `R/biplot.R` — 2 occurrences (`geom_vline()` / `geom_hline()` for zero reference lines)
- `R/utils.R` — 1 occurrence (`element_line()` in `mixo_gg.theme()`)
- `DESCRIPTION` — removed unused `gsignal` from Imports
- `R/mixOmics-package.R` — tidied roxygen headers (replaced `@docType package` + trailing `NULL` with `"_PACKAGE"` sentinel per current roxygen convention)
- `man/mixOmics-package.Rd` — regenerated (title quoting)
- `R/plotLoadings.R` + `man/plotLoadings.Rd` — fixed roxygen markup typo (`code{mint.pls}` → `\code{mint.pls}`)
- `inst/README-WhatsNew.Rmd` — added entry under April 2026