### PR TITLE
PR addressing Issue #381

### DIFF
--- a/R/S3methods-print.R
+++ b/R/S3methods-print.R
@@ -475,14 +475,14 @@ print.rgcca <- function(x, ...)
     cat("\nCall:\n", deparse(x$call, width.cutoff = 500), "\n\n")
     
     # components
-    for(k in 1:length(x$blocks)){
+    for(k in 1:length(x$X)){
         cat(" rGCCA with", x$ncomp[k], "components on block", k, "named", x$names$blocks[k], "\n")
     }
     cat("\n")
     
     # dimension
-    for(k in 1 : length(x$blocks)){
-        cat(" Dimension of block", k, 'is ', dim(x$blocks[[k]]), "\n")
+    for(k in 1 : length(x$X)){
+        cat(" Dimension of block", k, 'is ', dim(x$X[[k]]), "\n")
     }
     cat("\n")
     cat(" Main numerical outputs: \n", "-------------------- \n")

--- a/R/S3methods-print.R
+++ b/R/S3methods-print.R
@@ -612,11 +612,12 @@ print.summary <-
         print.gap = 4
         what = x$what
         digits = x$digits
+        method = x$method
         
         #--------------------- output pls/spls ---------------------#
-        if(inherits(x, c("pls", "spls"))){
+        if(isTRUE(method %in% c("pls", "spls"))){
             
-            if (is(x, "pls"))
+            if (identical(method, "pls"))
             {
                 cat(" PLS mode:", x$mode)
                 cat("\n Number of variates considered:", x$ncomp, "\n")
@@ -661,7 +662,7 @@ print.summary <-
         }  #end if pls
         
         # ---------------------- output rcc ------------------------#
-        if(is(x, "rcc"))
+        if(identical(method, "rcc"))
         {
             print.gap = 4
             if (any(what == "all"))
@@ -955,5 +956,3 @@ print.predict = function(x, ...)
     }
     
 }
-
-

--- a/R/summary.R
+++ b/R/summary.R
@@ -333,7 +333,7 @@ summary.pca <-
     function (object, ...)
     {
         chkDots(...)
-        vars <- object$prop_expl_var
+        vars <- object$prop_expl_var$X
         importance <- rbind(`Standard deviation` = object$sdev, `Proportion of Variance` = round(vars,
                                                                                                  5), `Cumulative Proportion` = round(cumsum(vars), 5))
         k <- ncol(object$rotation)

--- a/R/summary.R
+++ b/R/summary.R
@@ -176,7 +176,7 @@ summary.mixo_pls <-
         #-- valeurs sortantes --#
         result$what = what
         result$digits = digits
-        if(is(object, "pls")) {
+        if(is(object, "mixo_pls")) {
             result$method = 'pls'
         } 
         else {

--- a/R/unmap.R
+++ b/R/unmap.R
@@ -60,21 +60,21 @@ unmap <-
             miss = match(groups, u, nomatch = 0) == 0
         }
         
-        cgroups = as.character(groups)
         if (!is.null(noise))
         {
             noiz = match(noise, groups, nomatch = 0)
             if (any(noiz == 0))
                 stop("noise incompatible with classification")
-            
+
             groups = c(groups[groups != noise], groups[groups == noise])
             noise = as.numeric(factor(as.character(noise), levels = unique(groups)))
         }
-        
+
+        cgroups = as.character(groups)
         groups = as.numeric(factor(cgroups, levels = unique(cgroups)))
         classification = as.numeric(factor(as.character(classification), levels = unique(cgroups)))
         k = length(groups) - length(noise)
-        nam = levels(groups)
+        nam = unique(cgroups)
         
         if (!is.null(noise))
         {
@@ -83,7 +83,7 @@ unmap <-
             nam[k] = "noise"
         }
         
-        z = matrix(0, n, k, dimnames = c(names(classification), nam))
+        z = matrix(0, n, k, dimnames = list(names(classification), nam))
         for (j in 1:k) z[classification == groups[j], j] = 1
         attr(z, "levels") = levels
         z

--- a/tests/testthat/test-diabolo.R
+++ b/tests/testthat/test-diabolo.R
@@ -79,3 +79,28 @@ test_that("block.splsda works", {
   expect_equal(nutrimouse.sgccda$variates$lipid[1, 1], 2.73351593820324)
   expect_equal(nutrimouse.sgccda$variates$Y[1, 1], 0.639567998302767)
 })
+
+test_that("Check.entry.wrapper.mint.block handles zero-variance predictors", {
+  samples = paste0("s", seq_len(8))
+  X = list(gene = cbind(g1 = seq_len(8), zero = 1, g2 = 8:1),
+           lipid = cbind(l1 = 2:9, l2 = 9:2))
+  Y = cbind(class1 = rep(c(1, 0), 4), class2 = rep(c(0, 1), 4))
+  rownames(X$gene) = rownames(X$lipid) = rownames(Y) = samples
+
+  nzv.check = Check.entry.wrapper.mint.block(
+    X = X, Y = Y, ncomp = 1, keepX = list(gene = 3, lipid = 2),
+    DA = TRUE, init = "svd.single", scheme = "horst", scale = TRUE,
+    near.zero.var = TRUE, mode = "regression", tol = 1e-06, max.iter = 10
+  )
+  expect_equal(ncol(nzv.check$A$gene), 2)
+  expect_equal(nzv.check$keepA$gene, 2)
+
+  expect_error(
+    Check.entry.wrapper.mint.block(
+      X = X, Y = Y, ncomp = 1, DA = TRUE, init = "svd.single",
+      scheme = "horst", scale = TRUE, near.zero.var = FALSE,
+      mode = "regression", tol = 1e-06, max.iter = 10
+    ),
+    "zero variance in block 'gene'", fixed = TRUE
+  )
+})

--- a/tests/testthat/test-internals.R
+++ b/tests/testthat/test-internals.R
@@ -4,7 +4,7 @@ test_that(".get.ind.colors works as expected", code = {
     foo <- .get.ind.colors(group = NULL, col = 'black', n_ind = 10)
     expect_true(length(foo) == 10)
     expect_true(identical(unique(foo), 'black'))
-    foo <- .get.ind.colors(group = factor(mtcars$am[1:10]), col = NULL, n_ind = 10, 
+    foo <- .get.ind.colors(group = factor(mtcars$am[1:10]), col = NULL, n_ind = 10,
                            col.per.group = c('1'='red', '0'='blue'))
     expect_true(length(foo) == 10)
     expect_true(all(names(foo) %in% c('red', 'blue')))
@@ -32,13 +32,13 @@ test_that(".check_test.keepX works as expected for single and list X", code = {
     expect_condition(.check_test.keepX(test.keepX = c(1, 2.2, 3), X = mtcars))
     expect_condition(.check_test.keepX(test.keepX = c(1, '2', 3), X = mtcars))
     expect_condition(.check_test.keepX(test.keepX = seq(3, ncol(mtcars)+1, 1), X = mtcars))
-    
+
     expect_equal(.check_test.keepX(
-        test.keepX = list('a'=c(1,4), 'b'=c(3,5,8)), 
+        test.keepX = list('a'=c(1,4), 'b'=c(3,5,8)),
         X =          list('a'=mtcars, 'b'=mtcars)
     ),
     list('a'=c(1,4), 'b'=c(3,5,8)))
-    
+
     expect_condition(.check_test.keepX(
         test.keepX = list('a'=c(1,4), 'b'=c(3,5,8)),
         X =          list('a'=mtcars, 'b'=mtcars, 'c'=mtcars  )
@@ -48,17 +48,49 @@ test_that(".check_test.keepX works as expected for single and list X", code = {
         X =          list('a'=mtcars, 'b'=mtcars)
     ))
     expect_condition(.check_test.keepX(
-        test.keepX = list('a'=c(1,4), 'b'=c(3,ncol(mtcars)+1)), 
+        test.keepX = list('a'=c(1,4), 'b'=c(3,ncol(mtcars)+1)),
         X =          list('a'=mtcars, 'b'=mtcars               )
     ))
-    
+
 })
 test_that(".check_ncomp works as expected for single and list X", code = {
     expect_true(.check_ncomp(ncomp=2, X = mtcars) == 2)
     expect_true(.check_ncomp(ncomp=2, X = list(a=mtcars, b=mtcars)) == 2)
     expect_condition(.check_ncomp(ncomp=min(dim(mtcars))+1, X = mtcars))
     expect_condition(.check_ncomp(ncomp=4, X = list(a=mtcars, b=mtcars[,1:3])))
-    
+
+})
+
+test_that("get.keepA validates and completes keepX", {
+    X <- list(
+        a = matrix(seq_len(24), nrow = 6),
+        b = matrix(seq_len(18), nrow = 6)
+    )
+
+    expect_error(get.keepA(X, keepX = c(a = 1), ncomp = c(2, 2)),
+                 "'keepX' must be a list", fixed = TRUE)
+    expect_error(get.keepA(X, keepX = list(a = ncol(X$a) + 1), ncomp = c(2, 2)),
+                 "must be lower or equal", fixed = TRUE)
+
+    keepA <- get.keepA(X, keepX = list(a = 1), ncomp = c(2, 2))$keepA
+    expect_equal(keepA$a, c(1, ncol(X$a)))
+    expect_equal(keepA$b, rep(ncol(X$b), 2))
+})
+
+test_that("Check.entry.pls adjusts keepX after near-zero variance removal", {
+    X <- cbind(a = seq_len(6), zero = 1, b = seq(2, 12, by = 2))
+    Y <- matrix(seq_len(6), ncol = 1)
+
+    nzv.check <- expect_warning(
+        Check.entry.pls(
+            X = X, Y = Y, ncomp = 1, keepX = ncol(X),
+            scale = TRUE, near.zero.var = TRUE, max.iter = 10, tol = 1e-06,
+            logratio = "none", DA = FALSE, multilevel = NULL
+        ),
+        "Zero- or near-zero variance predictors", fixed = TRUE
+    )
+    expect_equal(ncol(nzv.check$X), 2)
+    expect_equal(nzv.check$keepX, 2)
 })
 
 test_that("ALL DA functions raise specific error when Y contains NAs", {

--- a/tests/testthat/test-ipca.R
+++ b/tests/testthat/test-ipca.R
@@ -40,7 +40,31 @@ test_that("ipca runs with custom w.init matrix", {
   expect_s3_class(ipca.res, "ipca")
 })
 
-# Test 6: Test for missing values in 'X'
+# Test 6: Test 'fun' parameter with exp function
+test_that("ipca runs with exp function in deflation mode", {
+  data(liver.toxicity)
+  ipca.res <- ipca(liver.toxicity$gene, ncomp = 3, mode = "deflation", fun = "exp", max.iter = 20)
+  expect_s3_class(ipca.res, "ipca")
+  expect_equal(ncol(ipca.res$x), 3)
+})
+
+# Test 7: Test 'mode' parameter with parallel algorithm
+test_that("ipca runs in parallel mode with logcosh", {
+  data(liver.toxicity)
+  ipca.res <- ipca(liver.toxicity$gene, ncomp = 3, mode = "parallel", fun = "logcosh", max.iter = 20)
+  expect_s3_class(ipca.res, "ipca")
+  expect_equal(ncol(ipca.res$x), 3)
+})
+
+# Test 8: Test parallel algorithm with exp function
+test_that("ipca runs in parallel mode with exp", {
+  data(liver.toxicity)
+  ipca.res <- ipca(liver.toxicity$gene, ncomp = 3, mode = "parallel", fun = "exp", max.iter = 20)
+  expect_s3_class(ipca.res, "ipca")
+  expect_equal(ncol(ipca.res$x), 3)
+})
+
+# Test 9: Test for missing values in 'X'
 test_that("ipca throws error if missing values in X", {
   data(liver.toxicity)
   liver.toxicity$gene[1, 1] <- NA  # Inject missing value

--- a/tests/testthat/test-mint.block.pls.R
+++ b/tests/testthat/test-mint.block.pls.R
@@ -1,17 +1,62 @@
 context("mint.block.pls")
 
-# Test
-test_that("mint.block.pls works", {
+.mint_block_pls_data <- function(nvar = NULL) {
   data(breast.TCGA)
-  study = c(rep("study1", 150), rep("study2", 70))
-  mrna = rbind(breast.TCGA$data.train$mrna, breast.TCGA$data.test$mrna)
-  mirna = rbind(breast.TCGA$data.train$mirna, breast.TCGA$data.test$mirna)
-  Y = mrna[, 1]
-  mrna = mrna[, -1]
-  data = list(mrna = mrna, mirna = mirna)
-  res = mint.block.plsda(data, Y, study=study, ncomp=2)
-  expect_equal(res$loadings$mrna[5], -0.08031856, tolerance = 1e-5)
+  X <- lapply(c("mrna", "mirna"), function(block) {
+    x <- rbind(breast.TCGA$data.train[[block]], breast.TCGA$data.test[[block]])
+    if (is.null(nvar)) x else x[, seq_len(nvar)]
+  })
+  names(X) <- c("mrna", "mirna")
+  Y <- as.matrix(X$mrna[, 1])
+  colnames(Y) <- "Y"
+  X$mrna <- X$mrna[, -1]
+  list(X = X, Y = Y, study = rep(c("study1", "study2"), c(150, 70)))
+}
+
+test_that("(mint.block.pls:basic): breast.TCGA", {
+  data <- .mint_block_pls_data()
+  res <- mint.block.pls(data$X, data$Y, study = data$study, ncomp = 2)
+
+  expect_true("mint.block.pls" %in% class(res))
+  expect_equal(res$loadings$mrna[5], -0.08196021, tolerance = 1e-5)
   expect_equal(res$mode, "regression")
 })
-  
-               
+
+test_that("(mint.block.pls:data): Y supplied through 'indY'", {
+  data <- .mint_block_pls_data(nvar = 20)
+  res <- mint.block.pls(c(data$X, list(Y = data$Y)), indY = 3,
+                        study = data$study, ncomp = 1)
+
+  expect_true("mint.block.pls" %in% class(res))
+  expect_equal(res$ncomp, c(mrna = 1, mirna = 1, Y = 1))
+})
+
+test_that("(mint.block.pls:parameter): block-only 'design'", {
+  data <- .mint_block_pls_data(nvar = 20)
+  design <- matrix(c(0, 0.5, 0.5, 0), nrow = 2)
+
+  expect_message(
+    res <- mint.block.pls(data$X, data$Y, study = data$study,
+                          design = design, ncomp = 1),
+    "Design matrix has changed to include Y"
+  )
+  expect_true("mint.block.pls" %in% class(res))
+  expect_equal(res$ncomp["Y"], c(Y = 1))
+})
+
+test_that("(mint.block.pls:error): invalid model inputs", {
+  data <- .mint_block_pls_data(nvar = 20)
+
+  expect_error(mint.block.pls(data$X, study = data$study),
+               "Either 'Y' or 'indY' is needed", fixed = TRUE)
+  expect_error(mint.block.pls(data$X, data$Y[, 1], study = data$study),
+               "'Y' must be a numeric matrix.", fixed = TRUE)
+})
+
+test_that("(mint.block.pls:edge.case): missing 'study'", {
+  data <- .mint_block_pls_data(nvar = 20)
+  res <- mint.block.pls(data$X, data$Y, ncomp = 1)
+
+  expect_true("mint.block.pls" %in% class(res))
+  expect_equal(table(res$study)[["1"]], nrow(data$X$mrna))
+})

--- a/tests/testthat/test-mint.block.plsda.R
+++ b/tests/testthat/test-mint.block.plsda.R
@@ -1,0 +1,88 @@
+context("mint.block.plsda")
+
+.mint_block_plsda_data <- function(nvar = NULL) {
+  data(breast.TCGA)
+  X <- lapply(c("mrna", "mirna"), function(block) {
+    x <- rbind(breast.TCGA$data.train[[block]], breast.TCGA$data.test[[block]])
+    if (is.null(nvar)) x else x[, seq_len(nvar)]
+  })
+  names(X) <- c("mrna", "mirna")
+  Y <- factor(c(as.character(breast.TCGA$data.train$subtype),
+                as.character(breast.TCGA$data.test$subtype)))
+  list(X = X, Y = Y, study = rep(c("study1", "study2"), c(150, 70)))
+}
+
+test_that("(mint.block.plsda:basic): breast.TCGA", {
+  data <- .mint_block_plsda_data()
+  res <- mint.block.plsda(data$X, data$Y, study = data$study, design = "full")
+
+  expect_true("mint.block.plsda" %in% class(res))
+  .expect_numerically_close(res$variates$mrna[1, 1], -7.503)
+  .expect_numerically_close(res$variates$Y[220, 2], -0.796)
+  .expect_numerically_close(res$loadings$mrna[1, 1], 0.100)
+  .expect_numerically_close(res$loadings$mirna[100, 2], -0.019)
+})
+
+test_that("(mint.block.plsda:data): Y supplied through 'indY'", {
+  data <- .mint_block_plsda_data(nvar = 20)
+  res <- mint.block.plsda(c(data$X, list(Y = data$Y)), indY = 3,
+                          study = data$study, ncomp = 1)
+
+  expect_true("mint.block.plsda" %in% class(res))
+  expect_equal(res$Y, data$Y)
+})
+
+test_that("(mint.block.plsda:data): near-zero variance predictors", {
+  data <- .mint_block_plsda_data(nvar = 10)
+  data$X$mrna <- cbind(zero = 1, data$X$mrna)
+
+  res <- mint.block.plsda(data$X, data$Y, study = data$study,
+                          ncomp = 1, near.zero.var = TRUE)
+  expect_false("zero" %in% colnames(res$X$mrna))
+})
+
+test_that("(mint.block.plsda:parameter): block-only 'design'", {
+  data <- .mint_block_plsda_data(nvar = 20)
+  design <- matrix(c(0, 0.5, 0.5, 0), nrow = 2)
+
+  expect_message(
+    res <- mint.block.plsda(data$X, data$Y, study = data$study,
+                            design = design, ncomp = 1),
+    "Design matrix has changed to include Y"
+  )
+  expect_equal(res$indY, 3L)
+})
+
+test_that("(mint.block.plsda:parameter): both 'Y' and 'indY' supplied", {
+  data <- .mint_block_plsda_data(nvar = 20)
+
+  expect_warning(
+    res <- mint.block.plsda(data$X, data$Y, indY = 1,
+                            study = data$study, ncomp = 1),
+    "'Y' and 'indY' are provided, 'Y' is used.", fixed = TRUE
+  )
+  expect_equal(res$Y, data$Y)
+})
+
+test_that("(mint.block.plsda:error): invalid inputs", {
+  data <- .mint_block_plsda_data(nvar = 20)
+  Y.with.na <- data$Y
+  Y.with.na[1] <- NA
+
+  expect_error(mint.block.plsda(data$X, Y = unmap(data$Y),
+                                study = data$study, ncomp = 1),
+               "'Y' should be a factor or a class vector.", fixed = TRUE)
+  expect_error(mint.block.plsda(data$X, Y = Y.with.na,
+                                study = data$study, ncomp = 1),
+               "Unmapped Y contains samples with no associated class", fixed = TRUE)
+  expect_error(mint.block.plsda(data$X, study = data$study),
+               "Either 'Y' or 'indY' is needed", fixed = TRUE)
+})
+
+test_that("(mint.block.plsda:edge.case): missing 'study'", {
+  data <- .mint_block_plsda_data(nvar = 20)
+  res <- mint.block.plsda(data$X, data$Y, ncomp = 1)
+
+  expect_true("mint.block.plsda" %in% class(res))
+  expect_equal(table(res$study)[["1"]], nrow(data$X$mrna))
+})

--- a/tests/testthat/test-mint.block.spls.R
+++ b/tests/testthat/test-mint.block.spls.R
@@ -1,18 +1,67 @@
 context("mint.block.spls")
 
-# Test
-test_that("mint.block.spls works", {
+.mint_block_spls_data <- function(nvar = NULL) {
   data(breast.TCGA)
-  study = c(rep("study1", 150), rep("study2", 70))
-  mrna = rbind(breast.TCGA$data.train$mrna, breast.TCGA$data.test$mrna)
-  mirna = rbind(breast.TCGA$data.train$mirna, breast.TCGA$data.test$mirna)
-  Y = mrna[, 1]
-  mrna = mrna[, -1]
-  data = list(mrna = mrna, mirna = mirna)
-  res = mint.block.splsda(data, Y, study=study, ncomp=2,
-                          keepX = list(mrna=c(10,10), mirna=c(20,20)))
+  X <- lapply(c("mrna", "mirna"), function(block) {
+    x <- rbind(breast.TCGA$data.train[[block]], breast.TCGA$data.test[[block]])
+    if (is.null(nvar)) x else x[, seq_len(nvar)]
+  })
+  names(X) <- c("mrna", "mirna")
+  Y <- as.matrix(X$mrna[, 1])
+  colnames(Y) <- "Y"
+  X$mrna <- X$mrna[, -1]
+  list(X = X, Y = Y, study = rep(c("study1", "study2"), c(150, 70)))
+}
+
+test_that("(mint.block.spls:basic): breast.TCGA", {
+  data <- .mint_block_spls_data()
+  res <- mint.block.spls(data$X, data$Y, study = data$study, ncomp = 2,
+                         keepX = list(mrna = c(10, 10), mirna = c(20, 20)),
+                         keepY = c(1, 1))
+
+  expect_true("mint.block.spls" %in% class(res))
   expect_equal(res$loadings$mrna[5], 0, tolerance = 1e-5)
   expect_equal(res$mode, "regression")
 })
-  
-               
+
+test_that("(mint.block.spls:data): Y supplied through 'indY'", {
+  data <- .mint_block_spls_data(nvar = 20)
+  res <- mint.block.spls(c(data$X, list(Y = data$Y)), indY = 3,
+                         study = data$study, ncomp = 1,
+                         keepX = list(mrna = 2, mirna = 3))
+
+  expect_true("mint.block.spls" %in% class(res))
+  expect_equal(res$keepX$comp1$Y, 1)
+  expect_null(res$keepY)
+})
+
+test_that("(mint.block.spls:parameter): partially specified 'keepX' and 'keepY'", {
+  data <- .mint_block_spls_data(nvar = 20)
+  res <- mint.block.spls(data$X, data$Y, study = data$study, ncomp = 2,
+                         keepX = list(mrna = 2), keepY = 1)
+
+  expect_equal(res$keepX$comp1$mrna, 2)
+  expect_equal(res$keepX$comp2$mrna, ncol(data$X$mrna))
+  expect_equal(res$keepX$comp1$Y, ncol(data$Y))
+})
+
+test_that("(mint.block.spls:error): invalid model inputs", {
+  data <- .mint_block_spls_data(nvar = 20)
+
+  expect_error(mint.block.spls(data$X, study = data$study),
+               "Either 'Y' or 'indY' is needed", fixed = TRUE)
+  expect_error(mint.block.spls(data$X, data$Y[, 1], study = data$study),
+               "'Y' must be a numeric matrix.", fixed = TRUE)
+  expect_error(mint.block.spls(data$X, data$Y, study = data$study,
+                               keepX = list(bad = c(1, 1)), ncomp = 2),
+               "Each entry of 'keepX' must have a unique name", fixed = TRUE)
+})
+
+test_that("(mint.block.spls:edge.case): single component", {
+  data <- .mint_block_spls_data(nvar = 20)
+  res <- mint.block.spls(data$X, data$Y, study = data$study, ncomp = 1,
+                         keepX = list(mrna = 2, mirna = 3), keepY = 1)
+
+  expect_true("mint.block.spls" %in% class(res))
+  expect_equal(ncol(res$variates$mrna), 1L)
+})

--- a/tests/testthat/test-mint.block.splsda.R
+++ b/tests/testthat/test-mint.block.splsda.R
@@ -1,72 +1,68 @@
+context("mint.block.splsda")
 
-
-###############################################################################
-### ================================ BASIC ================================ ###
-###############################################################################
-
-test_that("mint.block.plsda and mint.block.splsda works", {
-  
+.mint_block_splsda_data <- function(nvar = NULL) {
   data(breast.TCGA)
-  mrna <- rbind(breast.TCGA$data.train$mrna, breast.TCGA$data.test$mrna)
-  mirna <- rbind(breast.TCGA$data.train$mirna, breast.TCGA$data.test$mirna)
-  X <- list(mrna = mrna, mirna = mirna)
-  Y <- c(breast.TCGA$data.train$subtype, breast.TCGA$data.test$subtype)
-  
-  study <- c(rep("study1",150), rep("study2",70))
-  
-  res.mint.block.plsda <- mint.block.plsda(X, Y, study=study, design="full")
-  
-  expect_true("mint.block.plsda" %in% class(res.mint.block.plsda))
-  .expect_numerically_close(res.mint.block.plsda$variates$mrna[1,1], -7.503)
-  .expect_numerically_close(res.mint.block.plsda$variates$Y[220,2], -0.796)
-  
-  .expect_numerically_close(res.mint.block.plsda$loadings$mrna[1,1], 0.100)
-  .expect_numerically_close(res.mint.block.plsda$loadings$mirna[100,2], -0.019)
-  
-  
-  res.mint.block.splsda <- mint.block.splsda(X, Y, study=study, design="full", keepX = list(mrna=c(2,2), mirna=c(3,3)))
-  
-  expect_true("mint.block.splsda" %in% class(res.mint.block.splsda))
-  .expect_numerically_close(res.mint.block.splsda$variates$mrna[1,1], -1.48)
-  .expect_numerically_close(res.mint.block.splsda$variates$Y[220,2], -0.5758)
-  
+  X <- lapply(c("mrna", "mirna"), function(block) {
+    x <- rbind(breast.TCGA$data.train[[block]], breast.TCGA$data.test[[block]])
+    if (is.null(nvar)) x else x[, seq_len(nvar)]
+  })
+  names(X) <- c("mrna", "mirna")
+  Y <- factor(c(as.character(breast.TCGA$data.train$subtype),
+                as.character(breast.TCGA$data.test$subtype)))
+  list(X = X, Y = Y, study = rep(c("study1", "study2"), c(150, 70)))
+}
+
+test_that("(mint.block.splsda:basic): breast.TCGA", {
+  data <- .mint_block_splsda_data()
+  res <- mint.block.splsda(data$X, data$Y, study = data$study, design = "full",
+                           keepX = list(mrna = c(2, 2), mirna = c(3, 3)))
+
+  expect_true("mint.block.splsda" %in% class(res))
+  .expect_numerically_close(res$variates$mrna[1, 1], -1.48)
+  .expect_numerically_close(res$variates$Y[220, 2], -0.5758)
 })
 
+test_that("(mint.block.splsda:data): Y supplied through 'indY'", {
+  data <- .mint_block_splsda_data(nvar = 20)
+  res <- mint.block.splsda(c(data$X, list(Y = data$Y)), indY = 3,
+                           study = data$study, ncomp = 1,
+                           keepX = list(mrna = 2, mirna = 3))
 
-###############################################################################
-### ================================ DATA ================================= ###
-###############################################################################
+  expect_true("mint.block.splsda" %in% class(res))
+  expect_equal(res$Y, data$Y)
+})
 
+test_that("(mint.block.splsda:parameter): partially specified 'keepX'", {
+  data <- .mint_block_splsda_data(nvar = 20)
+  res <- mint.block.splsda(data$X, data$Y, study = data$study,
+                           ncomp = 2, keepX = list(mrna = 2))
 
+  expect_equal(res$keepX$comp1$mrna, 2)
+  expect_equal(res$keepX$comp2$mrna, ncol(data$X$mrna))
+  expect_equal(res$keepX$comp1$Y, nlevels(data$Y))
+})
 
+test_that("(mint.block.splsda:error): invalid inputs", {
+  data <- .mint_block_splsda_data(nvar = 20)
 
+  expect_error(mint.block.splsda(data$X, Y = unmap(data$Y),
+                                 study = data$study, ncomp = 1),
+               "'Y' should be a factor or a class vector.", fixed = TRUE)
+  expect_error(mint.block.splsda(data$X, Y = rep("Basal", length(data$Y)),
+                                 study = data$study, ncomp = 1),
+               "'Y' should be a factor with more than one level", fixed = TRUE)
+  expect_error(mint.block.splsda(data$X, study = data$study),
+               "Either 'Y' or 'indY' is needed", fixed = TRUE)
+  expect_error(mint.block.splsda(data$X, data$Y, study = data$study,
+                                 keepX = list(bad = c(1, 1)), ncomp = 2),
+               "Each entry of 'keepX' must have a unique name", fixed = TRUE)
+})
 
-###############################################################################
-### ============================== PARAMETER ============================== ###
-###############################################################################
+test_that("(mint.block.splsda:edge.case): single component", {
+  data <- .mint_block_splsda_data(nvar = 20)
+  res <- mint.block.splsda(data$X, data$Y, study = data$study,
+                           ncomp = 1, keepX = list(mrna = 2, mirna = 3))
 
-
-
-
-
-###############################################################################
-### ================================ ERROR ================================ ###
-###############################################################################
-
-
-
-
-
-###############################################################################
-### ============================== EDGE CASES ============================= ###
-###############################################################################
-
-
-
-
-
-###############################################################################
-
-# if the method is a graphical function, include the following:
-#dev.off()
-#unlink(list.files(pattern = "*.pdf"))
+  expect_true("mint.block.splsda" %in% class(res))
+  expect_equal(ncol(res$variates$mrna), 1L)
+})

--- a/tests/testthat/test-sipca.R
+++ b/tests/testthat/test-sipca.R
@@ -53,3 +53,27 @@ test_that("sipca runs with custom w.init matrix", {
   sipca.res <- sipca(liver.toxicity$gene, ncomp = 3, mode = "deflation", w.init = w.init)
   expect_s3_class(sipca.res, "sipca")
 })
+
+# Test 8: Test 'fun' parameter with exp function
+test_that("sipca runs with exp function in deflation mode", {
+  data(liver.toxicity)
+  sipca.res <- sipca(liver.toxicity$gene, ncomp = 3, mode = "deflation", fun = "exp")
+  expect_s3_class(sipca.res, "sipca")
+  expect_equal(ncol(sipca.res$x), 3)
+})
+
+# Test 9: Test 'mode' parameter with parallel algorithm
+test_that("sipca runs in parallel mode with logcosh", {
+  data(liver.toxicity)
+  sipca.res <- sipca(liver.toxicity$gene, ncomp = 3, mode = "parallel", fun = "logcosh")
+  expect_s3_class(sipca.res, "sipca")
+  expect_equal(ncol(sipca.res$x), 3)
+})
+
+# Test 10: Test parallel algorithm with exp function
+test_that("sipca runs in parallel mode with exp", {
+  data(liver.toxicity)
+  sipca.res <- sipca(liver.toxicity$gene, ncomp = 3, mode = "parallel", fun = "exp")
+  expect_s3_class(sipca.res, "sipca")
+  expect_equal(ncol(sipca.res$x), 3)
+})

--- a/tests/testthat/test-summary.R
+++ b/tests/testthat/test-summary.R
@@ -1,0 +1,108 @@
+context("summary")
+
+test_that("(summary:basic): pls", {
+    data(linnerud)
+    object <- pls(linnerud$exercise, linnerud$physiological, ncomp = 2)
+
+    out <- summary(object)
+
+    expect_s3_class(out, "summary")
+    expect_equal(out$method, "pls")
+    expect_equal(out$ncomp, object$ncomp)
+    expect_equal(out$mode, object$mode)
+    expect_equal(out$keep.var$X, colnames(object$X))
+    expect_equal(out$keep.var$Y, colnames(object$Y))
+
+    expect_equal(dim(out$Cm.X$own), c(ncol(object$X), object$ncomp))
+    expect_equal(dim(out$Cm.X$opp), c(ncol(object$X), object$ncomp))
+    expect_equal(dim(out$Cm.Y$own), c(ncol(object$Y), object$ncomp))
+    expect_equal(dim(out$Cm.Y$opp), c(ncol(object$Y), object$ncomp))
+    expect_equal(colnames(out$Cm.X$own), paste("comp", seq_len(object$ncomp)))
+
+    expect_equal(dim(out$Rd.X$own), c(object$ncomp, 2))
+    expect_equal(dim(out$Rd.Y$own), c(object$ncomp, 2))
+    expect_equal(colnames(out$Rd.X$own), c("Proportion", "Cumulative"))
+    expect_equal(colnames(out$Rd.Y$own), c("Proportion", "Cumulative"))
+
+    expect_equal(out$VIP, vip(object))
+    expect_match(paste(capture.output(print(out)), collapse = "\n"),
+                 "PLS mode:")
+})
+
+test_that("(summary:parameter): spls, 'what' and 'keep.var'", {
+    data(linnerud)
+    object <- spls(linnerud$exercise, linnerud$physiological, ncomp = 2,
+                   keepX = c(2, 2), keepY = c(2, 2))
+
+    out <- summary(object, what = c("redundancy", "VIP"), keep.var = TRUE)
+
+    selected.X <- apply(object$loadings$X != 0, 1, any)
+    selected.Y <- apply(object$loadings$Y != 0, 1, any)
+
+    expect_s3_class(out, "summary")
+    expect_equal(out$method, "spls")
+    expect_equal(out$keepX, object$keepX)
+    expect_equal(out$keepY, object$keepY)
+    expect_equal(out$keep.var$X, colnames(object$X)[selected.X])
+    expect_equal(out$keep.var$Y, colnames(object$Y)[selected.Y])
+
+    expect_null(out$Cm.X)
+    expect_equal(dim(out$Rd.X$own), c(object$ncomp, 2))
+    expect_equal(dim(out$VIP), c(sum(selected.X), object$ncomp))
+    expect_equal(out$VIP, vip(object)[selected.X, ])
+    expect_match(paste(capture.output(print(out)), collapse = "\n"),
+                 "sPLS mode:")
+})
+
+test_that("(summary:basic): rcc", {
+    data(linnerud)
+    object <- rcc(linnerud$exercise, linnerud$physiological, ncomp = 2,
+                  lambda1 = 0.1, lambda2 = 0.1)
+
+    out <- summary(object)
+
+    expect_s3_class(out, "summary")
+    expect_equal(out$method, "rcc")
+    expect_equal(out$ncomp, object$ncomp)
+    expect_equal(out$cor, setNames(object$cor[seq_len(object$ncomp)],
+                                   paste(seq_len(object$ncomp), "th", sep = "")))
+    expect_equal(out$can.cor, out$cor)
+    expect_null(out$cutoff)
+    expect_equal(out$keep$X, colnames(object$X))
+    expect_equal(out$keep$Y, colnames(object$Y))
+
+    expect_equal(dim(out$Cm.X$own), c(ncol(object$X), object$ncomp))
+    expect_equal(dim(out$Rd.X$own), c(object$ncomp, 2))
+    expect_equal(rownames(out$Rd.X$own), paste("comp", seq_len(object$ncomp)))
+    expect_match(paste(capture.output(print(out)), collapse = "\n"),
+                 "Canonical correlations")
+
+})
+
+test_that("(summary:error): rcc cutoff selects no variables", {
+    data(linnerud)
+    object <- rcc(linnerud$exercise, linnerud$physiological, ncomp = 2,
+                  lambda1 = 0.1, lambda2 = 0.1)
+
+    expect_error(summary(object, cutoff = 2), "No variable was selected")
+})
+
+test_that("(summary:basic): pca", {
+    data(linnerud)
+    object <- pca(linnerud$exercise, ncomp = 2, scale = TRUE)
+
+    out <- summary(object)
+
+    expect_s3_class(out, "summary.prcomp")
+    expect_equal(dim(out$importance), c(3, object$ncomp))
+    expect_equal(rownames(out$importance),
+                 c("Standard deviation",
+                   "Proportion of Variance",
+                   "Cumulative Proportion"))
+    expect_equal(colnames(out$importance), colnames(object$rotation))
+    expect_equal(out$importance["Standard deviation", ], object$sdev)
+    expect_equal(out$importance["Proportion of Variance", ],
+                 round(object$prop_expl_var$X, 5))
+    expect_equal(out$importance["Cumulative Proportion", ],
+                 round(cumsum(object$prop_expl_var$X), 5))
+})

--- a/tests/testthat/test-unmap.R
+++ b/tests/testthat/test-unmap.R
@@ -1,0 +1,74 @@
+context("unmap and map")
+
+test_that("(unmap:basic): factor input with default args", {
+    data(nutrimouse)
+    Y <- unmap(nutrimouse$diet)
+
+    expect_true(is.matrix(Y))
+    expect_equal(nrow(Y), length(nutrimouse$diet))
+    expect_equal(ncol(Y), nlevels(nutrimouse$diet))
+    expect_equal(unname(rowSums(Y)), rep(1, nrow(Y)))
+    expect_equal(attr(Y, "levels"), levels(nutrimouse$diet))
+})
+
+test_that("(unmap:basic): character vector input", {
+    Y <- unmap(c("a", "b", "a", "c"))
+
+    expect_equal(dim(Y), c(4, 3))
+    expect_equal(unname(rowSums(Y)), rep(1, 4))
+    expect_null(attr(Y, "levels"))
+})
+
+test_that("(unmap:parameter): groups", {
+    cls <- c("a", "b", "a")
+    Y <- unmap(cls, groups = c("a", "b"))
+
+    expect_equal(dim(Y), c(3, 2))
+    expect_equal(unname(rowSums(Y)), rep(1, 3))
+})
+
+test_that("(unmap:error): groups incompatible with classification", {
+    expect_error(
+        unmap(c("a", "b", "c"), groups = c("a", "b")),
+        "groups incompatible with classification"
+    )
+})
+
+test_that("(unmap:parameter): noise places noise class last", {
+    Y <- unmap(c("a", "b", "noise", "a"), noise = "noise")
+
+    expect_equal(nrow(Y), 4)
+    expect_equal(colnames(Y), c("a", "b", "noise"))
+    expect_equal(unname(Y[, "noise"]), c(0, 0, 1, 0))
+})
+
+test_that("(unmap:edge.case): noise reorder preserves encoding", {
+    Y <- unmap(c("a", "0", "b"), groups = c("0", "a", "b"), noise = "0")
+
+    expect_equal(colnames(Y), c("a", "b", "noise"))
+    expect_equal(unname(Y[, "a"]), c(1, 0, 0))
+    expect_equal(unname(Y[, "b"]), c(0, 0, 1))
+    expect_equal(unname(Y[, "noise"]), c(0, 1, 0))
+})
+
+test_that("(unmap:error): noise incompatible with groups", {
+    expect_error(
+        unmap(c("a", "b", "c"), noise = "missing_class"),
+        "noise incompatible with classification"
+    )
+})
+
+test_that("(map:basic): one-hot matrix", {
+    Y <- diag(3)
+    expect_equal(map(Y), 1:3)
+})
+
+test_that("(map:edge.case): ties resolved to first column", {
+    Y <- rbind(c(1, 1, 0), c(0, 1, 1))
+    expect_equal(map(Y), c(1, 2))
+})
+
+test_that("(unmap:basic): round-trip via map preserves codes", {
+    data(nutrimouse)
+    expect_equal(map(unmap(nutrimouse$diet)), as.integer(nutrimouse$diet))
+})

--- a/tests/testthat/test-vip.R
+++ b/tests/testthat/test-vip.R
@@ -1,0 +1,109 @@
+context("vip")
+
+test_that("(vip:basic): pls, multivariate Y", {
+    data(linnerud)
+    res <- pls(linnerud$exercise, linnerud$physiological, ncomp = 2)
+
+    v <- vip(res)
+
+    expect_true(is.matrix(v))
+    expect_equal(dim(v), c(ncol(linnerud$exercise), 2))
+    expect_equal(rownames(v), colnames(linnerud$exercise))
+    expect_equal(colnames(v), c("comp1", "comp2"))
+    # VIP invariant: column-wise sum of squared VIPs equals p
+    expect_equal(colSums(v^2),
+                 setNames(rep(ncol(linnerud$exercise), 2), c("comp1", "comp2")))
+})
+
+test_that("(vip:data): pls, linnerud reference values", {
+    data(linnerud)
+    res <- pls(linnerud$exercise, linnerud$physiological, ncomp = 2)
+
+    v <- vip(res)
+
+    # Regression baseline — guards against silent changes to the VIP formula
+    expected <- matrix(
+        c(1.062280, 1.293793, 0.444592,
+          0.904423, 1.139641, 0.939807),
+        nrow = 3, ncol = 2,
+        dimnames = list(c("Chins", "Situps", "Jumps"),
+                        c("comp1", "comp2"))
+    )
+    expect_equal(v, expected, tolerance = 1e-5)
+})
+
+test_that("(vip:edge.case): pls, univariate Y (q == 1)", {
+    data(linnerud)
+    res <- pls(linnerud$exercise, linnerud$physiological[, 1, drop = FALSE],
+               ncomp = 2)
+
+    v <- vip(res)
+
+    expect_equal(dim(v), c(ncol(linnerud$exercise), 2))
+    expect_equal(colSums(v^2),
+                 setNames(rep(ncol(linnerud$exercise), 2), c("comp1", "comp2")))
+})
+
+test_that("(vip:basic): spls", {
+    data(liver.toxicity)
+    res <- spls(liver.toxicity$gene, liver.toxicity$clinic,
+                ncomp = 2, keepX = c(50, 50), keepY = c(10, 10))
+
+    v <- vip(res)
+
+    expect_equal(dim(v), c(ncol(liver.toxicity$gene), 2))
+    expect_equal(rownames(v), colnames(liver.toxicity$gene))
+    expect_equal(colnames(v), c("comp1", "comp2"))
+    # sparse loadings are still unit-norm, so the invariant must hold
+    expect_equal(colSums(v^2),
+                 setNames(rep(ncol(liver.toxicity$gene), 2),
+                          c("comp1", "comp2")))
+})
+
+test_that("(vip:basic): plsda", {
+    data(breast.tumors)
+    X <- breast.tumors$gene.exp
+    Y <- as.factor(breast.tumors$sample$treatment)
+    res <- plsda(X, Y, ncomp = 2)
+
+    v <- vip(res)
+
+    expect_equal(dim(v), c(ncol(X), 2))
+    expect_equal(colSums(v^2), setNames(rep(ncol(X), 2), c("comp1", "comp2")))
+})
+
+test_that("(vip:basic): splsda", {
+    data(breast.tumors)
+    X <- breast.tumors$gene.exp
+    Y <- as.factor(breast.tumors$sample$treatment)
+    res <- splsda(X, Y, ncomp = 2, keepX = c(25, 25))
+
+    v <- vip(res)
+
+    expect_equal(dim(v), c(ncol(X), 2))
+    expect_equal(rownames(v), colnames(X))
+    expect_equal(colnames(v), c("comp1", "comp2"))
+    expect_equal(colSums(v^2), setNames(rep(ncol(X), 2), c("comp1", "comp2")))
+})
+
+test_that("(vip:edge.case): ncomp == 1", {
+    data(linnerud)
+    res <- pls(linnerud$exercise, linnerud$physiological, ncomp = 1)
+
+    v <- vip(res)
+
+    expect_equal(dim(v), c(ncol(linnerud$exercise), 1))
+    expect_equal(colnames(v), "comp1")
+    # comp1 is always sqrt(p) * |W[, 1]| regardless of Y dimensionality
+    expect_equal(unname(v[, 1]),
+                 unname(sqrt(ncol(linnerud$exercise)) * abs(res$loadings$X[, 1])))
+})
+
+test_that("(vip:error): unsupported object classes", {
+    data(linnerud)
+    res.pca <- pca(linnerud$exercise, ncomp = 2)
+    expect_error(vip(res.pca),
+                 "'vip' is only implemented for the following objects")
+    expect_error(vip(list(a = 1)),
+                 "'vip' is only implemented for the following objects")
+})

--- a/tests/testthat/test-wrapper.sgcca.R
+++ b/tests/testthat/test-wrapper.sgcca.R
@@ -1,0 +1,21 @@
+context("wrapper.sgcca")
+
+test_that("(wrapper.sgcca:basic): nutrimouse blocks", {
+  data(nutrimouse)
+  X <- list(gene = nutrimouse$gene[, 1:20],
+            lipid = nutrimouse$lipid[, 1:10])
+  design <- matrix(c(0, 1, 1, 0), nrow = 2)
+
+  res <- wrapper.sgcca(
+    X, design = design, ncomp = 2,
+    keepX = list(gene = c(5, 5), lipid = c(5, 5))
+  )
+  selected <- sapply(res$loadings, function(x) colSums(x != 0))
+
+  expect_s3_class(res, "sgcca")
+  expect_equal(names(res$X), names(X))
+  expect_equal(lapply(res$X, dim), lapply(X, dim))
+  expect_equal(res$ncomp, c(gene = 2, lipid = 2))
+  expect_equal(selected, matrix(5, nrow = 2, ncol = 2,
+                                dimnames = list(c("comp1", "comp2"), names(X))))
+})


### PR DESCRIPTION
## Summary

Addresses #381 by expanding test coverage for under-tested model utilities and internal helper paths, including `unmap`, `ica.def.par`, `check_entry`, `summary`, `vip`, `wrapper.sgcca`, and MINT block methods.

The PR also includes small fixes discovered while adding coverage.

## Changes

- `tests/testthat/test-unmap.R` — added coverage for `unmap()` / `map()`, including factor/character inputs, `groups`, `noise`, error paths, ties, and round-trip behaviour
- `tests/testthat/test-ipca.R` + `tests/testthat/test-sipca.R` — added coverage for ICA-related PCA paths, including `deflation` / `parallel` modes and `logcosh` / `exp` functions
- `tests/testthat/test-internals.R` — added coverage for `get.keepA()` and `Check.entry.pls()` near-zero variance handling
- `tests/testthat/test-diabolo.R` — added coverage for `Check.entry.wrapper.mint.block()` zero-variance predictor handling
- `tests/testthat/test-summary.R` — added coverage for `summary()` on PLS, sPLS, RCC, and PCA objects
- `tests/testthat/test-vip.R` — added coverage for `vip()` on PLS, sPLS, PLS-DA, and sPLS-DA objects
- `tests/testthat/test-wrapper.sgcca.R` — added basic coverage for `wrapper.sgcca()`
- `tests/testthat/test-mint.block.pls.R`, `test-mint.block.plsda.R`, `test-mint.block.spls.R`, `test-mint.block.splsda.R` — expanded MINT block coverage for basic runs, `indY`, design handling, partial `keepX`, missing study, and invalid inputs
- `R/unmap.R` — fixed class/noise reordering so encoded columns and names are preserved correctly
- `R/summary.R` — fixed PCA summary explained variance lookup from `prop_expl_var$X`
- `R/S3methods-print.R` — fixed summary method detection and updated `print.rgcca()` to use current `x$X` block storage
