### PR TITLE
PR addressing Issue # 377

### DIFF
--- a/R/plotLoadings.plsda.R
+++ b/R/plotLoadings.plsda.R
@@ -157,8 +157,6 @@ plotLoadings.mixo_plsda <-
                         par(mar = c(4, max(7, max(sapply(colnames.X, nchar),na.rm = TRUE)/3), 4, 2))
                     }
                     
-                    xlim <- xlim[1,]
-
                     .plotLoadings_barplot(height = df$importance, col = df$color, names.arg = colnames.X, 
                     cex.name = size.name, border = border, xlim = xlim[i, ], 
                     xlab = X.label, ylab = Y.label, cex.lab = size.labs, cex.axis = size.axis)

--- a/tests/testthat/test-plotLoadings.sgccda.R
+++ b/tests/testthat/test-plotLoadings.sgccda.R
@@ -57,6 +57,21 @@ test_that("Test contrib parameter functionality", {
   expect_true(all(sapply(result, function(x) "color" %in% colnames(x))))  # Check for color column
 })
 
+test_that("plotLoadings supports vector xlim with sgccda contrib", {
+  skip_on_cran()
+  skip_on_ci()
+
+  png(tempfile(), width = 1200, height = 1000, res = 150)
+  old_par <- par(no.readonly = TRUE)
+  on.exit({
+    par(old_par)
+    dev.off()
+  })
+  result <- plotLoadings(diablo.obj, contrib = "max", xlim = c(-0.5, 0.5))
+  expect_equal(length(result), 2)
+  expect_true(all(sapply(result, function(x) "color" %in% colnames(x))))
+})
+
 # Error: plotLoadings encountered margin errors. Ensure feature names are not too long and the "Plots" pane is enlarged.
 # # Unit test 4: Test method parameter
 # test_that("Test method parameter functionality", {
@@ -160,6 +175,3 @@ test_that("plotLoadings works for sgccda ggplot2", {
                         legend.title = "Test Legend"))
   ))
 })
-
-
-


### PR DESCRIPTION
## Summary

Addresses #377 by fixing vector `xlim` handling in the `graphics` branch of `plotLoadings()` for block sPLS-DA / `sgccda` contribution plots.

The bug was caused by flattening the internally normalised `xlim` matrix before it was indexed with `xlim[i, ]`, resulting in `incorrect number of dimensions`.

## Changes

- `R/plotLoadings.plsda.R` — removed the extra `xlim <- xlim[1, ]` assignment inside the `graphics` contribution plotting branch so block-specific indexing with `xlim[i, ]` is preserved
- `tests/testthat/test-plotLoadings.sgccda.R` — added coverage for `plotLoadings()` with `sgccda`, `contrib = "max"`, and vector `xlim` in the `graphics` branch
